### PR TITLE
Add initial mapping b/w defaults:pypi and conda-forge:pypi

### DIFF
--- a/db/conda-forge-pypi.toml
+++ b/db/conda-forge-pypi.toml
@@ -1,0 +1,13217 @@
+[[package]]
+description = "ABlog for blogging with Sphinx"
+conda-forge = "ablog"
+pypi = "ablog"
+
+
+[[package]]
+description = "Abseil Python Common Libraries, see https://github.com/abseil/abseil-py."
+conda-forge = "absl-py"
+pypi = "absl-py"
+
+
+[[package]]
+description = "The ADAL for Python library makes it easy for python application to authenticate\nto Azure Active Directory (AAD) in order to access AAD protected web resources.\n"
+conda-forge = "adal"
+pypi = "adal"
+
+
+[[package]]
+description = "A Python interface to NASA ADS."
+conda-forge = "ads"
+pypi = "ads"
+
+
+[[package]]
+description = "Advanced Enumerations (compatible with Python's stdlib Enum), NamedTuples,"
+conda-forge = "aenum"
+pypi = "aenum"
+
+
+[[package]]
+description = "Matrices describing affine transformation of the plane."
+conda-forge = "affine"
+pypi = "affine"
+
+
+[[package]]
+description = "agate-dbf adds read support for dbf files to agate."
+conda-forge = "agate-dbf"
+pypi = "agate-dbf"
+
+
+[[package]]
+description = "agate-excel adds read support for Excel files (xls and xlsx) to agate."
+conda-forge = "agate-excel"
+pypi = "agate-excel"
+
+
+[[package]]
+description = "agate-lookup adds remote lookup tables to agate."
+conda-forge = "agate-lookup"
+pypi = "agate-lookup"
+
+
+[[package]]
+description = "A data analysis library that is optimized for humans instead of machines."
+conda-forge = "agate"
+pypi = "agate"
+
+
+[[package]]
+description = "agate-remote adds read support for remote files to agate."
+conda-forge = "agate-remote"
+pypi = "agate-remote"
+
+
+[[package]]
+description = "agate-sql adds SQL read/write support to agate."
+conda-forge = "agate-sql"
+pypi = "agate-sql"
+
+
+[[package]]
+description = "agate-stats adds additional statistical methods to agate."
+conda-forge = "agate-stats"
+pypi = "agate-stats"
+
+
+[[package]]
+description = "High quality drawing interface for PIL."
+conda-forge = "aggdraw"
+pypi = "aggdraw"
+
+
+[[package]]
+description = "ago: Human readable timedeltas"
+conda-forge = "ago"
+pypi = "ago"
+
+
+[[package]]
+description = "Async client for aws services using botocore and aiohttp"
+conda-forge = "aiobotocore"
+pypi = "aiobotocore"
+
+
+[[package]]
+description = "A straight-forward WebDAV client, ported from easywebdav to use aiohttp."
+conda-forge = "aioeasywebdav"
+pypi = "aioeasywebdav"
+
+
+[[package]]
+description = "File support for asyncio"
+conda-forge = "aiofiles"
+pypi = "aiofiles"
+
+
+[[package]]
+description = "Async http client/server framework (asyncio)"
+conda-forge = "aiohttp"
+pypi = "aiohttp"
+
+
+[[package]]
+description = "aiomysql is a library for accessing a MySQL database from the asyncio"
+conda-forge = "aiomysql"
+pypi = "aiomysql"
+
+
+[[package]]
+description = "Asyncio interface for Peewee ORM"
+conda-forge = "aiopeewee"
+pypi = "aiopeewee"
+
+
+[[package]]
+description = "Asynchronous SMTP client for use with asyncio."
+conda-forge = "aiosmtplib"
+pypi = "aiosmtplib"
+
+
+[[package]]
+description = "Configurable, Python 2+3 compatible Sphinx theme."
+conda-forge = "alabaster"
+pypi = "alabaster"
+
+
+[[package]]
+description = "SQLAlchemy to Django integration library"
+conda-forge = "aldjemy"
+pypi = "aldjemy"
+
+
+[[package]]
+description = "A database migration tool for SQLAlchemy."
+conda-forge = "alembic"
+pypi = "alembic"
+
+
+[[package]]
+description = "ALGOPY: Taylor Arithmetic Computation and Algorithmic Differentiation"
+conda-forge = "algopy"
+pypi = "algopy"
+
+
+[[package]]
+description = "Behavior Driven Development using Cucumber for Python"
+conda-forge = "aloe"
+pypi = "aloe"
+
+
+[[package]]
+description = "Performance analysis of predictive (alpha) stock factors"
+conda-forge = "alphalens"
+pypi = "alphalens"
+
+
+[[package]]
+description = "High-level declarative visualization library for Python."
+conda-forge = "altair"
+pypi = "altair"
+
+
+[[package]]
+description = "altgraph is a fork of graphlib"
+conda-forge = "altgraph"
+pypi = "altgraph"
+
+
+[[package]]
+description = "Low-level AMQP client for Python (fork of amqplib)"
+conda-forge = "amqp"
+pypi = "amqp"
+
+
+[[package]]
+description = "Tool for encapsulating, running, and reproducing data science projects"
+conda-forge = "anaconda-project"
+pypi = "anaconda-project"
+
+
+[[package]]
+description = "A library for parsing ISO 8601 strings."
+conda-forge = "aniso8601"
+pypi = "aniso8601"
+
+
+[[package]]
+description = "Ansible is a radically simple IT automation platform"
+conda-forge = "ansible"
+pypi = "ansible"
+
+
+[[package]]
+description = "This is the Python runtime for ANTLR."
+conda-forge = "antlr-python-runtime"
+pypi = "antlr4-python3-runtime"
+
+
+[[package]]
+description = "Loads whichever is the fastest JSON module installed and provides a uniform API"
+conda-forge = "anyjson"
+pypi = "anyjson"
+
+
+[[package]]
+description = "PyQt4/PyQt5 compatibility layer."
+conda-forge = "anyqt"
+pypi = "AnyQt"
+
+
+[[package]]
+description = "Automated gridded climate data analysis and management"
+conda-forge = "aospy"
+pypi = "aospy"
+
+
+[[package]]
+description = "Python library for interacting with many of the popular cloud service providers using a unified API"
+conda-forge = "apache-libcloud"
+pypi = "apache-libcloud"
+
+
+[[package]]
+description = "With apipkg you can control the exported namespace of a python package and greatly reduce the number of imports for your users."
+conda-forge = "apipkg"
+pypi = "apipkg"
+
+
+[[package]]
+description = "A pluggable API specification generator"
+conda-forge = "apispec"
+pypi = "apispec"
+
+
+[[package]]
+description = "A smart Web API framework, designed for Python 3"
+conda-forge = "apistar"
+pypi = "apistar"
+
+
+[[package]]
+description = "The Astronomical Plotting Library in Python"
+conda-forge = "aplpy"
+pypi = "aplpy"
+
+
+[[package]]
+description = "Promises/A+ for Python"
+conda-forge = "aplus"
+pypi = "aplus"
+
+
+[[package]]
+description = "A small Python module for determining appropriate platform-specific dirs."
+conda-forge = "appdirs"
+pypi = "appdirs"
+
+
+[[package]]
+description = "A Jupyter extensions that turns notebooks into web applications."
+conda-forge = "appmode"
+pypi = "appmode"
+
+
+[[package]]
+description = "Python implementation of Bayesian Approximate Posterior Estimation algorithm"
+conda-forge = "approxposterior"
+pypi = "approxposterior"
+
+
+[[package]]
+description = "application tools"
+conda-forge = "apptools"
+pypi = "apptools"
+
+
+[[package]]
+description = "In-process task scheduler with Cron-like capabilities"
+conda-forge = "apscheduler"
+pypi = "APScheduler"
+
+
+[[package]]
+description = "Bash tab completion for argparse"
+conda-forge = "argcomplete"
+pypi = "argcomplete"
+
+
+[[package]]
+description = "The Natural CLI."
+conda-forge = "argh"
+pypi = "argh"
+
+
+[[package]]
+description = "The secure Argon2 password hashing algorithm."
+conda-forge = "argon2_cffi"
+pypi = "argon2_cffi"
+
+
+[[package]]
+description = "Command Arguments for Humans."
+conda-forge = "args"
+pypi = "args"
+
+
+[[package]]
+description = "Python ARM Radar Toolkit"
+conda-forge = "arm_pyart"
+pypi = "arm_pyart"
+
+
+[[package]]
+description = "Write a 3-D NumPy array to a GIF, or an array of them to an animated GIF."
+conda-forge = "array2gif"
+pypi = "array2gif"
+
+
+[[package]]
+description = "Better dates & times for Python."
+conda-forge = "arrow"
+pypi = "arrow"
+
+
+[[package]]
+description = "ASAM MDF measurement data file parser"
+conda-forge = "asammdf"
+pypi = "asammdf"
+
+
+[[package]]
+description = "Package to help people create full-screen text UIs"
+conda-forge = "asciimatics"
+pypi = "asciimatics"
+
+
+[[package]]
+description = "Terminal session recorder and the best companion of asciinema.org."
+conda-forge = "asciinema"
+pypi = "asciinema"
+
+
+[[package]]
+description = "Draws ASCII trees."
+conda-forge = "asciitree"
+pypi = "asciitree"
+
+
+[[package]]
+description = "Python tools to handle ASDF files"
+conda-forge = "asdf"
+pypi = "asdf"
+
+
+[[package]]
+description = "ASE is a python package providing an open source Atomic Simulation Environment in the Python language."
+conda-forge = "ase"
+pypi = "ase"
+
+
+[[package]]
+description = "Python ASN.1 library with a focus on performance and a pythonic API"
+conda-forge = "asn1crypto"
+pypi = "asn1crypto"
+
+
+[[package]]
+description = "Assertion library for python unit testing with a fluent API"
+conda-forge = "assertpy"
+pypi = "assertpy"
+
+
+[[package]]
+description = "A package for solving ordinary differential equations and differential algebraic equations."
+conda-forge = "assimulo"
+pypi = "Assimulo"
+
+
+[[package]]
+description = "Check Python ASTs against templates"
+conda-forge = "astcheck"
+pypi = "astcheck"
+
+
+[[package]]
+description = "Simple and robust expressions evaluator for Python"
+conda-forge = "asteval"
+pypi = "asteval"
+
+
+[[package]]
+description = "Read, rewrite, and write Python ASTs nicely"
+conda-forge = "astor"
+pypi = "astor"
+
+
+[[package]]
+description = "Open astronomy catalogs"
+conda-forge = "astrocats"
+pypi = "astrocats"
+
+
+[[package]]
+description = "Galactic and gravitational dynamics in Python"
+conda-forge = "astro-gala"
+pypi = "astro-gala"
+
+
+[[package]]
+description = "A abstract syntax tree for Python with inference support."
+conda-forge = "astroid"
+pypi = "astroid"
+
+
+[[package]]
+description = "Tools for machine learning and data mining in Astronomy"
+conda-forge = "astroml"
+pypi = "astroML"
+
+
+[[package]]
+description = "Observation planning package for astronomers"
+conda-forge = "astroplan"
+pypi = "astroplan"
+
+
+[[package]]
+description = "BSD-licensed HEALPix for Astropy"
+conda-forge = "astropy-healpix"
+pypi = "astropy-healpix"
+
+
+[[package]]
+description = "Community-developed Python Library for Astronomy"
+conda-forge = "astropy"
+pypi = "astropy"
+
+
+[[package]]
+description = "The sphinx theme for Astropy and affiliated packages"
+conda-forge = "astropy-sphinx-theme"
+pypi = "astropy-sphinx-theme"
+
+
+[[package]]
+description = "Functions and classes to access online astronomical data resources."
+conda-forge = "astroquery"
+pypi = "astroquery"
+
+
+[[package]]
+description = "Speedy Cosmic Ray Annihilation Package in Python"
+conda-forge = "astroscrappy"
+pypi = "astroscrappy"
+
+
+[[package]]
+description = "The asttokens module annotates Python abstract syntax trees (ASTs) with the positions of tokens and text in the source code that generated them."
+conda-forge = "asttokens"
+pypi = "asttokens"
+
+
+[[package]]
+description = "An AST unparser for Python."
+conda-forge = "astunparse"
+pypi = "astunparse"
+
+
+[[package]]
+description = "A simple Python benchmarking tool with web-based reporting"
+conda-forge = "asv"
+pypi = "asv"
+
+
+[[package]]
+description = "Async generators and context managers for Python 3.5+"
+conda-forge = "async_generator"
+pypi = "async_generator"
+
+
+[[package]]
+description = "A fast PostgreSQL Database Client Library for Python/asyncio."
+conda-forge = "asyncpgsa"
+pypi = "asyncpgsa"
+
+
+[[package]]
+description = "Timeout context manager for asyncio programs"
+conda-forge = "async-timeout"
+pypi = "async-timeout"
+
+
+[[package]]
+description = "Atomic file writes."
+conda-forge = "atomicwrites"
+pypi = "atomicwrites"
+
+
+[[package]]
+description = "Memory efficient Python objects"
+conda-forge = "atom"
+pypi = "atom"
+
+
+[[package]]
+description = "A dict with attribute-style access"
+conda-forge = "attrdict"
+pypi = "attrdict"
+
+
+[[package]]
+description = "attrs is the Python package that will bring back the joy of writing classes by relieving you from the drudgery of implementing object protocols (aka dunder methods)."
+conda-forge = "attrs"
+pypi = "attrs"
+
+
+[[package]]
+description = "multi-library, cross-platform audio decoding"
+conda-forge = "audioread"
+pypi = "audioread"
+
+
+[[package]]
+description = "Linux wheel verification tool to ensure compatibility"
+conda-forge = "auditwheel"
+pypi = "auditwheel"
+
+
+[[package]]
+description = "WebSocket and WAMP in Python for Twisted and asyncio"
+conda-forge = "autobahn"
+pypi = "autobahn"
+
+
+[[package]]
+description = "Extending your autodoc API docs with a summary"
+conda-forge = "autodocsumm"
+pypi = "autodocsumm"
+
+
+[[package]]
+description = "Efficiently computes derivatives of numpy code."
+conda-forge = "autograd"
+pypi = "autograd"
+
+
+[[package]]
+description = "A tool that automatically formats Python code to conform to the PEP 8 style guide"
+conda-forge = "autopep8"
+pypi = "autopep8"
+
+
+[[package]]
+description = "An Auto-Visualization library for pandas dataframes"
+conda-forge = "autovizwidget"
+pypi = "autovizwidget"
+
+
+[[package]]
+description = "Generates Python Extension modules from commented Cython CXD files"
+conda-forge = "autowrap"
+pypi = "autowrap"
+
+
+[[package]]
+description = "Pythonic bindings for FFmpeg."
+conda-forge = "av"
+pypi = "av"
+
+
+[[package]]
+description = "Python flexible slugify function"
+conda-forge = "awesome-slugify"
+pypi = "awesome-slugify"
+
+
+[[package]]
+description = "AWSCLI CloudWatch Logs plugin"
+conda-forge = "awscli-cwlogs"
+pypi = "awscli-cwlogs"
+
+
+[[package]]
+description = "Universal Command Line Environment for AWS."
+conda-forge = "awscli"
+pypi = "awscli"
+
+
+[[package]]
+description = "Research tool for Iterated Prisoners Dilemma in Python"
+conda-forge = "axelrod"
+pypi = "Axelrod"
+
+
+[[package]]
+description = "Human-computer interface experimentation library"
+conda-forge = "axopy"
+pypi = "axopy"
+
+
+[[package]]
+description = "Microsoft Azure Client Libraries for Python"
+conda-forge = "azure-common"
+pypi = "azure-common"
+
+
+[[package]]
+description = "Microsoft Azure Resource Management Client Library for Python (Common)"
+conda-forge = "azure-mgmt-common"
+pypi = "azure-mgmt-common"
+
+
+[[package]]
+description = "Microsoft Azure Client Libraries for Python"
+conda-forge = "azure-mgmt-compute"
+pypi = "azure-mgmt-compute"
+
+
+[[package]]
+description = "Microsoft Azure Network Resource Management Client Library for Python"
+conda-forge = "azure-mgmt-network"
+pypi = "azure-mgmt-network"
+
+
+[[package]]
+description = "Microsoft Azure Resource Management Namespace Package"
+conda-forge = "azure-mgmt-nspkg"
+pypi = "azure-mgmt-nspkg"
+
+
+[[package]]
+description = "Microsoft Azure Client Libraries for Python"
+conda-forge = "azure-mgmt"
+pypi = "azure-mgmt"
+
+
+[[package]]
+description = "Microsoft Azure Resource Management Client Library for Python"
+conda-forge = "azure-mgmt-resource"
+pypi = "azure-mgmt-resource"
+
+
+[[package]]
+description = "Microsoft Azure Storage Resource Management Client Library for Python"
+conda-forge = "azure-mgmt-storage"
+pypi = "azure-mgmt-storage"
+
+
+[[package]]
+description = "Microsoft Azure Namespace Package [Internal]"
+conda-forge = "azure-nspkg"
+pypi = "azure-nspkg"
+
+
+[[package]]
+description = "Microsoft Azure Client Libraries for Python"
+conda-forge = "azure"
+pypi = "azure"
+
+
+[[package]]
+description = "Microsoft Azure Service Bus Client Library for Python"
+conda-forge = "azure-servicebus"
+pypi = "azure-servicebus"
+
+
+[[package]]
+description = "Microsoft Azure Legacy Service Management Client Library for Python"
+conda-forge = "azure-servicemanagement-legacy"
+pypi = "azure-servicemanagement-legacy"
+
+
+[[package]]
+description = "Microsoft Azure Storage Client Library for Python"
+conda-forge = "azure-storage"
+pypi = "azure-storage"
+
+
+[[package]]
+description = "Utilities to internationalize and localize Python applications"
+conda-forge = "babel"
+pypi = "Babel"
+
+
+[[package]]
+description = "Specifications for callback functions passed in to an API"
+conda-forge = "backcall"
+pypi = "backcall"
+
+
+[[package]]
+description = "Function decoration for backoff and retry"
+conda-forge = "backoff"
+pypi = "backoff"
+
+
+[[package]]
+description = "Useful utilities for Python."
+conda-forge = "backpack"
+pypi = "backpack"
+
+
+[[package]]
+description = "A backport of recent additions to the `collections.abc` module."
+conda-forge = "backports_abc"
+pypi = "backports_abc"
+
+
+[[package]]
+description = "Backport of Python 3's csv module for Python 2"
+conda-forge = "backports.csv"
+pypi = "backports.csv"
+
+
+[[package]]
+description = "Backport of functools.lru_cache from Python 3.3 as published at ActiveState."
+conda-forge = "backports.functools_lru_cache"
+pypi = "backports.functools_lru_cache"
+
+
+[[package]]
+description = "Backport of Python 3.3's 'lzma' module for XZ/LZMA compressed files."
+conda-forge = "backports.lzma"
+pypi = "backports.lzma"
+
+
+[[package]]
+description = "Backport of new features in Python's os module"
+conda-forge = "backports.os"
+pypi = "backports.os"
+
+
+[[package]]
+description = "A backport of the get_terminal_size function from Python 3.3's shutil."
+conda-forge = "backports.shutil_get_terminal_size"
+pypi = "backports.shutil_get_terminal_size"
+
+
+[[package]]
+description = "Backport of shutil.which from Python 3.3"
+conda-forge = "backports.shutil_which"
+pypi = "backports.shutil_which"
+
+
+[[package]]
+description = "The Python 3.4 standard `ssl` module API implemented on top of pyOpenSSL"
+conda-forge = "backports.ssl"
+pypi = "backports.ssl"
+
+
+[[package]]
+description = "Backports of new features in Python's tempfile module"
+conda-forge = "backports.tempfile"
+pypi = "backports.tempfile"
+
+
+[[package]]
+description = "Backport of Python 3's test.support package"
+conda-forge = "backports.test.support"
+pypi = "backports.test.support"
+
+
+[[package]]
+description = "Backport of new features in Python's weakref module"
+conda-forge = "backports.weakref"
+pypi = "backports.weakref"
+
+
+[[package]]
+description = "Work with BagIt packages from Python"
+conda-forge = "bagit"
+pypi = "bagit"
+
+
+[[package]]
+description = "a pure Python, OS-agnositic Binary Alignment Map (BAM) file parser and random access tool."
+conda-forge = "bamnostic"
+pypi = "bamnostic"
+
+
+[[package]]
+description = "Python parser for bash"
+conda-forge = "bashlex"
+pypi = "bashlex"
+
+
+[[package]]
+description = "ReST document generation tools for botocore."
+conda-forge = "bcdoc"
+pypi = "bcdoc"
+
+
+[[package]]
+description = "A columnar data container that can be compressed"
+conda-forge = "bcolz"
+pypi = "bcolz"
+
+
+[[package]]
+description = "A Session and Caching library with WSGI Middleware"
+conda-forge = "beaker"
+pypi = "Beaker"
+
+
+[[package]]
+description = "Python library designed for screen-scraping"
+conda-forge = "beautifulsoup4"
+pypi = "beautifulsoup4"
+
+
+[[package]]
+description = "beem is an unofficial python library for steem."
+conda-forge = "beem"
+pypi = "beem"
+
+
+[[package]]
+description = "Command line programs for busy developers"
+conda-forge = "begins"
+pypi = "begins"
+
+
+[[package]]
+description = "behave is behaviour-driven development, Python style"
+conda-forge = "behave"
+pypi = "behave"
+
+
+[[package]]
+description = "A VCR imitation for python-requests"
+conda-forge = "betamax-matchers"
+pypi = "betamax-matchers"
+
+
+[[package]]
+description = "Lightweight python wrapper for Betfair API-NG"
+conda-forge = "betfairlightweight"
+pypi = "betfairlightweight"
+
+
+[[package]]
+description = "BETSEE, the BioElectric Tissue Simulation Engine Environment"
+conda-forge = "betsee"
+pypi = "betsee"
+
+
+[[package]]
+description = "BETSE, the BioElectric Tissue Simulation Engine"
+conda-forge = "betse"
+pypi = "betse"
+
+
+[[package]]
+description = "A BGEN file format reader"
+conda-forge = "bgen-reader"
+pypi = "bgen-reader"
+
+
+[[package]]
+description = "Sampling from the Bayesian posterior of hidden Markov models."
+conda-forge = "bhmm"
+pypi = "bhmm"
+
+
+[[package]]
+description = "A module for parsing BibTeX files."
+conda-forge = "bibtexparser"
+pypi = "bibtexparser"
+
+
+[[package]]
+description = "Generates and manipulates the physical parameters of a bicycle."
+conda-forge = "bicycleparameters"
+pypi = "BicycleParameters"
+
+
+[[package]]
+description = "Efficient, Pythonic bidirectional map implementation and related functionality"
+conda-forge = "bidict"
+pypi = "bidict"
+
+
+[[package]]
+description = "Python multiprocessing fork with improvements and bugfixes"
+conda-forge = "billiard"
+pypi = "billiard"
+
+
+[[package]]
+description = "Ultra-lightweight pure Python package to check if a file is binary or text.\n"
+conda-forge = "binaryornot"
+pypi = "binaryornot"
+
+
+[[package]]
+description = "Binary-, RedBlack- and AVL-Trees in Python and Cython"
+conda-forge = "bintrees"
+pypi = "bintrees"
+
+
+[[package]]
+description = "Molecular Structures in Pandas DataFrames"
+conda-forge = "biopandas"
+pypi = "biopandas"
+
+
+[[package]]
+description = "Collection of freely available tools for computational molecular biology"
+conda-forge = "biopython"
+pypi = "biopython"
+
+
+[[package]]
+description = "efficient arrays of booleans -- C extension"
+conda-forge = "bitarray"
+pypi = "bitarray"
+
+
+[[package]]
+description = "Python bit pack/unpack package."
+conda-forge = "bitstruct"
+pypi = "bitstruct"
+
+
+[[package]]
+description = "High level chart types built on top of Bokeh"
+conda-forge = "bkcharts"
+pypi = "bkcharts"
+
+
+[[package]]
+description = "The Uncompromising Code Formatter"
+conda-forge = "black"
+pypi = "black"
+
+
+[[package]]
+description = "Bleach is a whitelist-based HTML sanitizing library that escapes or strips markup and attributes."
+conda-forge = "bleach"
+pypi = "bleach"
+
+
+[[package]]
+description = "A thin, practical wrapper around terminal capabilities in Python"
+conda-forge = "blessings"
+pypi = "blessings"
+
+
+[[package]]
+description = "Fast, simple object-to-object and broadcast signaling"
+conda-forge = "blinker"
+pypi = "blinker"
+
+
+[[package]]
+description = "Command line interface to and serialization format for Blosc"
+conda-forge = "bloscpack"
+pypi = "bloscpack"
+
+
+[[package]]
+description = "Bob's audio processing utilities"
+conda-forge = "bob.ap"
+pypi = "bob.ap"
+
+
+[[package]]
+description = "Bindings for Blitz++ (a C++ array template library)"
+conda-forge = "bob.blitz"
+pypi = "bob.blitz"
+
+
+[[package]]
+description = "Logging and RNG for Bob"
+conda-forge = "bob.core"
+pypi = "bob.core"
+
+
+[[package]]
+description = "ATNT/ORL Database Access API for Bob"
+conda-forge = "bob.db.atnt"
+pypi = "bob.db.atnt"
+
+
+[[package]]
+description = "Bob's Basic Database API"
+conda-forge = "bob.db.base"
+pypi = "bob.db.base"
+
+
+[[package]]
+description = "Bob access API for Fisher's Iris Flower Dataset"
+conda-forge = "bob.db.iris"
+pypi = "bob.db.iris"
+
+
+[[package]]
+description = "MNIST Database Access API for Bob"
+conda-forge = "bob.db.mnist"
+pypi = "bob.db.mnist"
+
+
+[[package]]
+description = "Wine Database for bob"
+conda-forge = "bob.db.wine"
+pypi = "bob.db.wine"
+
+
+[[package]]
+description = "Building of Python/C++ extensions for Bob"
+conda-forge = "bob.extension"
+pypi = "bob.extension"
+
+
+[[package]]
+description = "Audio I/O support for Bob"
+conda-forge = "bob.io.audio"
+pypi = "bob.io.audio"
+
+
+[[package]]
+description = "Basic IO for Bob"
+conda-forge = "bob.io.base"
+pypi = "bob.io.base"
+
+
+[[package]]
+description = "Image I/O support for Bob"
+conda-forge = "bob.io.image"
+pypi = "bob.io.image"
+
+
+[[package]]
+description = "Enable bob.io.base to handle Matlab(R) files"
+conda-forge = "bob.io.matlab"
+pypi = "bob.io.matlab"
+
+
+[[package]]
+description = "Video I/O support for Bob"
+conda-forge = "bob.io.video"
+pypi = "bob.io.video"
+
+
+[[package]]
+description = "Basic Image Processing Utilities for Bob"
+conda-forge = "bob.ip.base"
+pypi = "bob.ip.base"
+
+
+[[package]]
+description = "Color Conversion Utilities of Bob"
+conda-forge = "bob.ip.color"
+pypi = "bob.ip.color"
+
+
+[[package]]
+description = "Line and Box drawing utilities of Bob"
+conda-forge = "bob.ip.draw"
+pypi = "bob.ip.draw"
+
+
+[[package]]
+description = "Face Detection using a Cascade of Boosted LBP Features"
+conda-forge = "bob.ip.facedetect"
+pypi = "bob.ip.facedetect"
+
+
+[[package]]
+description = "Python bindings to the flandmark keypoint localization library"
+conda-forge = "bob.ip.flandmark"
+pypi = "bob.ip.flandmark"
+
+
+[[package]]
+description = "C++ code and Python bindings for Bob's Gabor wavelet analysis tools"
+conda-forge = "bob.ip.gabor"
+pypi = "bob.ip.gabor"
+
+
+[[package]]
+description = "Python bindings to the optical flow framework of Horn & Schunck"
+conda-forge = "bob.ip.optflow.hornschunck"
+pypi = "bob.ip.optflow.hornschunck"
+
+
+[[package]]
+description = "Python bindings to the optical flow framework by C. Liu"
+conda-forge = "bob.ip.optflow.liu"
+pypi = "bob.ip.optflow.liu"
+
+
+[[package]]
+description = "Bindings for bob.machine's Activation functors"
+conda-forge = "bob.learn.activation"
+pypi = "bob.learn.activation"
+
+
+[[package]]
+description = "Boosting framework for Bob"
+conda-forge = "bob.learn.boosting"
+pypi = "bob.learn.boosting"
+
+
+[[package]]
+description = "Bindings for emelaneous machines and trainers of Bob"
+conda-forge = "bob.learn.em"
+pypi = "bob.learn.em"
+
+
+[[package]]
+description = "Bob's Python bindings to LIBSVM"
+conda-forge = "bob.learn.libsvm"
+pypi = "bob.learn.libsvm"
+
+
+[[package]]
+description = "Bob's Linear Machine and its Trainers"
+conda-forge = "bob.learn.linear"
+pypi = "bob.learn.linear"
+
+
+[[package]]
+description = "Bob's Multi-layer Perceptron and Trainers"
+conda-forge = "bob.learn.mlp"
+pypi = "bob.learn.mlp"
+
+
+[[package]]
+description = "LAPACK and BLAS interfaces for Bob"
+conda-forge = "bob.math"
+pypi = "bob.math"
+
+
+[[package]]
+description = "Bob's evalution metrics"
+conda-forge = "bob.measure"
+pypi = "bob.measure"
+
+
+[[package]]
+description = "Bob is a free signal-processing and machine learning toolbox originally developed by the Biometrics group at Idiap Research Institute, in Switzerland."
+conda-forge = "bob"
+pypi = "bob"
+
+
+[[package]]
+description = "Bob's signal processing utilities"
+conda-forge = "bob.sp"
+pypi = "bob.sp"
+
+
+[[package]]
+description = "Statistical and novel interactive HTML plots for Python"
+conda-forge = "bokeh"
+pypi = "bokeh"
+
+
+[[package]]
+description = "Python module to produce bootstrapped confidence intervals and effect sizes."
+conda-forge = "bootstrap_contrast"
+pypi = "bootstrap_contrast"
+
+
+[[package]]
+description = "Amazon Web Services SDK for Python"
+conda-forge = "boto3"
+pypi = "boto3"
+
+
+[[package]]
+description = "Low-level, data-driven core of boto 3."
+conda-forge = "botocore"
+pypi = "botocore"
+
+
+[[package]]
+description = "Fast NumPy array functions written in Cython."
+conda-forge = "bottleneck"
+pypi = "Bottleneck"
+
+
+[[package]]
+description = "A Bower-centric static file server for WSGI"
+conda-forge = "bowerstatic"
+pypi = "bowerstatic"
+
+
+[[package]]
+description = "Interactive Dashboard Toolkit"
+conda-forge = "bowtie-py"
+pypi = "bowtie"
+
+
+[[package]]
+description = "Plotting library for Jupyter"
+conda-forge = "bqplot"
+pypi = "bqplot"
+
+
+[[package]]
+description = "This library is a spinoff from folium with the non-map-specific features"
+conda-forge = "branca"
+pypi = "branca"
+
+
+[[package]]
+description = "An extension to reStructuredText and Sphinx to be able to read and render the Doxygen xml output."
+conda-forge = "breathe"
+pypi = "breathe"
+
+
+[[package]]
+description = "Brent's method for univariate function optimization."
+conda-forge = "brent_search"
+pypi = "brent_search"
+
+
+[[package]]
+description = "Brent's method for univariate function optimization."
+conda-forge = "brent-search"
+pypi = "brent-search"
+
+
+[[package]]
+description = "Connect colorbrewer2.org color maps to Python and matplotlib"
+conda-forge = "brewer2mpl"
+pypi = "brewer2mpl"
+
+
+[[package]]
+description = "A clock-driven simulator for spiking neural networks"
+conda-forge = "brian2"
+pypi = "Brian2"
+
+
+[[package]]
+description = "Python bindings to the Brotli compression library"
+conda-forge = "brotlipy"
+pypi = "brotlipy"
+
+
+[[package]]
+description = "Independent BSON codec for Python that doesn't depend on MongoDB."
+conda-forge = "bson"
+pypi = "bson"
+
+
+[[package]]
+description = "Build and distribute C/C++ static libraries"
+conda-forge = "build_capi"
+pypi = "build_capi"
+
+
+[[package]]
+description = "Build and distribute C/C++ static libraries"
+conda-forge = "build-capi"
+pypi = "build-capi"
+
+
+[[package]]
+description = "Version-bump your software with a single command!"
+conda-forge = "bumpversion"
+pypi = "bumpversion"
+
+
+[[package]]
+description = "A dot-accessible dictionary (a la JavaScript objects)"
+conda-forge = "bunch"
+pypi = "bunch"
+
+
+[[package]]
+description = "Certificates for use with other packages."
+conda-forge = "ca-certificates"
+pypi = "certifi"
+
+
+[[package]]
+description = "The httplib2 caching algorithms packaged up for use with requests"
+conda-forge = "cachecontrol"
+pypi = "CacheControl"
+
+
+[[package]]
+description = "A decorator for caching properties in classes."
+conda-forge = "cached-property"
+pypi = "cached-property"
+
+
+[[package]]
+description = "Extensible memoizing collections and decorators"
+conda-forge = "cachetools"
+pypi = "cachetools"
+
+
+[[package]]
+description = "cffi-based cairo bindings for Python"
+conda-forge = "cairocffi"
+pypi = "cairocffi"
+
+
+[[package]]
+description = "A Simple SVG Converter based on Cairo"
+conda-forge = "cairosvg"
+pypi = "CairoSVG"
+
+
+[[package]]
+description = "OCR Engine based on OCRopy and Kraken based on python3."
+conda-forge = "calamari_ocr"
+pypi = "calamari_ocr"
+
+
+[[package]]
+description = "A multi-scale energy systems (MUSES) modeling framework"
+conda-forge = "calliope"
+pypi = "calliope"
+
+
+[[package]]
+description = "Easily capture stdout/stderr of the current process and subprocesses."
+conda-forge = "capturer"
+pypi = "capturer"
+
+
+[[package]]
+description = "Python unittest Utilities"
+conda-forge = "case"
+pypi = "case"
+
+
+[[package]]
+description = "Python driver for Cassandra"
+conda-forge = "cassandra-driver"
+pypi = "cassandra-driver"
+
+
+[[package]]
+description = "A collection of sklearn transformers to encode categorical variables as numeric"
+conda-forge = "category_encoders"
+pypi = "category_encoders"
+
+
+[[package]]
+description = "Complex custom class converters for attrs."
+conda-forge = "cattrs"
+pypi = "cattrs"
+
+
+[[package]]
+description = "A package for getting more cats into your code"
+conda-forge = "catzzz"
+pypi = "catzzz"
+
+
+[[package]]
+description = "Astropy affiliated package for reducing optical/IR CCD data"
+conda-forge = "ccdproc"
+pypi = "ccdproc"
+
+
+[[package]]
+description = "cChardet is high speed universal character encoding detector."
+conda-forge = "cchardet"
+pypi = "cchardet"
+
+
+[[package]]
+description = "Compliance Checker NCEI Templates Compliance plugin."
+conda-forge = "cc-plugin-ncei"
+pypi = "cc-plugin-ncei"
+
+
+[[package]]
+description = "UGRID plugin for the IOOS Compliance Checker Plugin"
+conda-forge = "cc-plugin-ugrid"
+pypi = "cc-plugin-ugrid"
+
+
+[[package]]
+description = "Distributed Task Queue"
+conda-forge = "celery"
+pypi = "celery"
+
+
+[[package]]
+description = "CLI Application Framework for Python"
+conda-forge = "cement"
+pypi = "cement"
+
+
+[[package]]
+description = "A wrapper for the US Census Bureau's API"
+conda-forge = "census"
+pypi = "census"
+
+
+[[package]]
+description = "Lightweight, extensible schema and data validation tool for Python dictionaries."
+conda-forge = "cerberus"
+pypi = "Cerberus"
+
+
+[[package]]
+description = "Python package for providing Mozilla's CA Bundle."
+conda-forge = "certifi"
+pypi = "certifi"
+
+
+[[package]]
+description = "Downloading, analyzing and visualizing CrossFit data"
+conda-forge = "cfanalytics"
+pypi = "cfanalytics"
+
+
+[[package]]
+description = "Foreign Function Interface for Python calling C code."
+conda-forge = "cffi"
+pypi = "cffi"
+
+
+[[package]]
+description = "Connectome File Format Library"
+conda-forge = "cfflib"
+pypi = "cfflib"
+
+
+[[package]]
+description = "Validate configuration and produce human readable error messages."
+conda-forge = "cfgv"
+pypi = "cfgv"
+
+
+[[package]]
+description = "Management of HPC clusters on Amazon Web Services using CloudFormation"
+conda-forge = "cfncluster"
+pypi = "cfncluster"
+
+
+[[package]]
+description = "Time-handling functionality from netcdf4-python"
+conda-forge = "cftime"
+pypi = "cftime"
+
+
+[[package]]
+description = "Units of measure as required by the Climate and Forecast (CF) metadata conventions."
+conda-forge = "cf_units"
+pypi = "cf_units"
+
+
+[[package]]
+description = "C/C++ source generation from an AST"
+conda-forge = "cgen"
+pypi = "cgen"
+
+
+[[package]]
+description = "Python library for managing cgroups"
+conda-forge = "cgroupspy"
+pypi = "cgroupspy"
+
+
+[[package]]
+description = "Easy to use mocking, stubbing and spying framework."
+conda-forge = "chai"
+pypi = "chai"
+
+
+[[package]]
+description = "Python client for the EPICS Channel Archiver."
+conda-forge = "channelarchiver"
+pypi = "channelarchiver"
+
+
+[[package]]
+description = "Universal character encoding detector"
+conda-forge = "chardet"
+pypi = "chardet"
+
+
+[[package]]
+description = "Create beautiful Javascript charts with minimal code"
+conda-forge = "chartkick"
+pypi = "chartkick"
+
+
+[[package]]
+description = "cheat allows you to create and view interactive cheatsheets on the command-line. It was designed to help remind *nix system administrators of options for commands that they use frequently, but not frequently enough to remember."
+conda-forge = "cheat"
+pypi = "cheat"
+
+
+[[package]]
+description = "Automatically extract chemical information from scientific documents."
+conda-forge = "chemdataextractor"
+pypi = "ChemDataExtractor"
+
+
+[[package]]
+description = "Highly-optimized, pure-python HTTP server"
+conda-forge = "cheroot"
+pypi = "Cheroot"
+
+
+[[package]]
+description = "Object-Oriented HTTP framework"
+conda-forge = "cherrypy"
+pypi = "CherryPy"
+
+
+[[package]]
+description = "Simple on-disk dictionary"
+conda-forge = "chest"
+pypi = "chest"
+
+
+[[package]]
+description = "Tools for discrete choice model estimation"
+conda-forge = "choicemodels"
+pypi = "choicemodels"
+
+
+[[package]]
+description = "Creation of new CIFTI files and the reading and manipulating of existing ones"
+conda-forge = "cifti"
+pypi = "cifti"
+
+
+[[package]]
+description = "Provides useful helpers for Circle CI"
+conda-forge = "circleci-helpers"
+pypi = "circleci-helpers"
+
+
+[[package]]
+description = "Python client for CircleCI API"
+conda-forge = "circleclient"
+pypi = "circleclient"
+
+
+[[package]]
+description = "Fast ISO8601 date time parser for Python written in C"
+conda-forge = "ciso8601"
+pypi = "ciso8601"
+
+
+[[package]]
+description = "A command line interface and Python module for accessing the CKAN Action API"
+conda-forge = "ckanapi"
+pypi = "ckanapi"
+
+
+[[package]]
+description = "Simple, fast, extensible JSON encoder/decoder for Python"
+conda-forge = "clamd"
+pypi = "clamd"
+
+
+[[package]]
+description = "CFFI bindings for CLD2"
+conda-forge = "cld2-cffi"
+pypi = "cld2-cffi"
+
+
+[[package]]
+description = "Enhanced completion for Click"
+conda-forge = "click-completion"
+pypi = "click-completion"
+
+
+[[package]]
+description = "Colorization of help messages in Click"
+conda-forge = "click-help-colors"
+pypi = "click-help-colors"
+
+
+[[package]]
+description = "Python-bindings for CityHash, a fast non-cryptographic hash algorithm"
+conda-forge = "clickhouse-cityhash"
+pypi = "clickhouse-cityhash"
+
+
+[[package]]
+description = "Python driver with native interface for ClickHouse"
+conda-forge = "clickhouse-driver"
+pypi = "clickhouse-driver"
+
+
+[[package]]
+description = "Simple ClickHouse SQLAlchemy Dialect"
+conda-forge = "clickhouse-sqlalchemy"
+pypi = "clickhouse-sqlalchemy"
+
+
+[[package]]
+description = "An extension module for click to enable registering CLI commands via setuptools entry-points."
+conda-forge = "click-plugins"
+pypi = "click-plugins"
+
+
+[[package]]
+description = "A simple wrapper around optparse for powerful command line utilities."
+conda-forge = "click"
+pypi = "click"
+
+
+[[package]]
+description = "Command Line Interface Formulation Framework"
+conda-forge = "cliff"
+pypi = "cliff"
+
+
+[[package]]
+description = "Click params for commmand line interfaces to GeoJSON."
+conda-forge = "cligj"
+pypi = "cligj"
+
+
+[[package]]
+description = "Python helpers for common CLI tasks"
+conda-forge = "cli_helpers"
+pypi = "cli_helpers"
+
+
+[[package]]
+description = "Python package for process-oriented climate modeling"
+conda-forge = "climlab"
+pypi = "climlab"
+
+
+[[package]]
+description = "Python Command Line Interface Tools"
+conda-forge = "clint"
+pypi = "clint"
+
+
+[[package]]
+description = "Asynchronous Cloudant / CouchDB Interface"
+conda-forge = "cloudant"
+pypi = "cloudant"
+
+
+[[package]]
+description = "Extended pickling support for Python objects"
+conda-forge = "cloudpickle"
+pypi = "cloudpickle"
+
+
+[[package]]
+description = "A nice sphinx theme named 'Cloud', and some related extensions."
+conda-forge = "cloud_sptheme"
+pypi = "cloud_sptheme"
+
+
+[[package]]
+description = "Galaxy Cluster and Weak Lensing Tools"
+conda-forge = "cluster-lensing"
+pypi = "cluster-lensing"
+
+
+[[package]]
+description = "Extra features for standard library's cmd module"
+conda-forge = "cmd2"
+pypi = "cmd2"
+
+
+[[package]]
+description = "Simple, elegant, Pythonic functional programming."
+conda-forge = "coconut"
+pypi = "coconut"
+
+
+[[package]]
+description = "Cog: A code generator for executing Python snippets in source files."
+conda-forge = "cogapp"
+pypi = "cogapp"
+
+
+[[package]]
+description = "A Faster Collectstatic "
+conda-forge = "collectfast"
+pypi = "Collectfast"
+
+
+[[package]]
+description = "Cross-platform colored terminal text."
+conda-forge = "colorama"
+pypi = "colorama"
+
+
+[[package]]
+description = "Colored terminal output for Python's logging module"
+conda-forge = "coloredlogs"
+pypi = "coloredlogs"
+
+
+[[package]]
+description = "Log formatting with colors!"
+conda-forge = "colorlog"
+pypi = "colorlog"
+
+
+[[package]]
+description = "Color scales in Python for humans"
+conda-forge = "colorlover"
+pypi = "colorlover"
+
+
+[[package]]
+description = "Utilities to ease manipulation of matplotlib colormaps and color codecs (e.g., hex2rgb)"
+conda-forge = "colormap"
+pypi = "9cf6bd10f0d2c4522504412ace0faeaac67f8e6280af6965a88f825c712d"
+
+
+[[package]]
+description = "Color math and conversion library."
+conda-forge = "colormath"
+pypi = "colormath"
+
+
+[[package]]
+description = "Python color representations manipulation library (RGB, HSL, web, ...)"
+conda-forge = "colour"
+pypi = "colour"
+
+
+[[package]]
+description = "Colour Science for Python"
+conda-forge = "colour-science"
+pypi = "colour-science"
+
+
+[[package]]
+description = "Python parser for the CommonMark Markdown spec"
+conda-forge = "commonmark"
+pypi = "CommonMark"
+
+
+[[package]]
+description = "Checks Datasets and SOS endpoints for standards compliance."
+conda-forge = "compliance-checker"
+pypi = "compliance-checker"
+
+
+[[package]]
+description = "Conan C/C++ package manager"
+conda-forge = "conan"
+pypi = "conan"
+
+
+[[package]]
+description = "Concurrent logging handler (drop-in replacement for RotatingFileHandler) Python 2.6+"
+conda-forge = "concurrentloghandler"
+pypi = "ConcurrentLogHandler"
+
+
+[[package]]
+description = "mirror an upstream conda channel to a local directory"
+conda-forge = "conda-mirror"
+pypi = "conda_mirror"
+
+
+[[package]]
+description = "Package conda environments for redistribution"
+conda-forge = "conda-pack"
+pypi = "conda-pack"
+
+
+[[package]]
+description = "Activate conda environments in subshells"
+conda-forge = "conda-workon"
+pypi = "conda-workon"
+
+
+[[package]]
+description = "replacement for argparse allowing options to be set via config files and/or env vars"
+conda-forge = "configargparse"
+pypi = "ConfigArgParse"
+
+
+[[package]]
+description = "CoNLL-U Parser parses a CoNLL-U formatted string into a nested python dictionary"
+conda-forge = "conllu"
+pypi = "conllu"
+
+
+[[package]]
+description = "Symbolic constants in Python"
+conda-forge = "constantly"
+pypi = "constantly"
+
+
+[[package]]
+description = "Contact maps based on MDTraj"
+conda-forge = "contact_map"
+pypi = "contact_map"
+
+
+[[package]]
+description = "Context geo-tiles in Python."
+conda-forge = "contextily"
+pypi = "contextily"
+
+
+[[package]]
+description = "Backports and enhancements for the contextlib module"
+conda-forge = "contextlib2"
+pypi = "contextlib2"
+
+
+[[package]]
+description = "PEP 567 Backport"
+conda-forge = "contextvars"
+pypi = "contextvars"
+
+
+[[package]]
+description = "Python Control Systems Library"
+conda-forge = "control"
+pypi = "control"
+
+
+[[package]]
+description = "A command-line utility that creates projects from cookiecutters (project templates). E.g. Python package projects, jQuery plugin projects.\n"
+conda-forge = "cookiecutter"
+pypi = "cookiecutter"
+
+
+[[package]]
+description = "Open-source thermodynamic and transport properties database"
+conda-forge = "coolprop"
+pypi = "CoolProp"
+
+
+[[package]]
+description = "An interactive command line client for Core API."
+conda-forge = "coreapi-cli"
+pypi = "coreapi-cli"
+
+
+[[package]]
+description = "Make some beautiful corner plots of samples."
+conda-forge = "corner"
+pypi = "corner"
+
+
+[[package]]
+description = "Script for downloading Coursera.org videos and naming them."
+conda-forge = "coursera-dl"
+pypi = "coursera-dl"
+
+
+[[package]]
+description = "Tools for courtship analysis"
+conda-forge = "courtana"
+pypi = "courtana"
+
+
+[[package]]
+description = "plugin core for use by pytest-cov, nose-cov and nose2-cov"
+conda-forge = "cov-core"
+pypi = "cov-core"
+
+
+[[package]]
+description = "Code coverage measurement for Python"
+conda-forge = "coverage"
+pypi = "coverage"
+
+
+[[package]]
+description = "Show coverage stats online via coveralls.io"
+conda-forge = "coveralls"
+pypi = "coveralls"
+
+
+[[package]]
+description = "Parse C++ header files and generate a data structure representing the class"
+conda-forge = "cppheaderparser"
+pypi = "CppHeaderParser"
+
+
+[[package]]
+description = "A simple testing framework for command line applications"
+conda-forge = "cram"
+pypi = "cram"
+
+
+[[package]]
+description = "CRC Generator"
+conda-forge = "crcmod"
+pypi = "crcmod"
+
+
+[[package]]
+description = "High performance approximate and streaming algorithms."
+conda-forge = "crick"
+pypi = "crick"
+
+
+[[package]]
+description = "Use Twisted anywhere!"
+conda-forge = "crochet"
+pypi = "crochet"
+
+
+[[package]]
+description = "croniter provides iteration for datetime object with cron like format"
+conda-forge = "croniter"
+pypi = "croniter"
+
+
+[[package]]
+description = "Parse and use crontab schedules in Python"
+conda-forge = "crontab"
+pypi = "crontab"
+
+
+[[package]]
+description = "Provides cryptographic recipes and primitives to Python developers"
+conda-forge = "cryptography"
+pypi = "cryptography"
+
+
+[[package]]
+description = "Test vectors for the cryptography package."
+conda-forge = "cryptography-vectors"
+pypi = "cryptography_vectors"
+
+
+[[package]]
+description = "A Coffescript Object Notation (CSON) parser for Python 2 and Python 3."
+conda-forge = "cson"
+pypi = "cson"
+
+
+[[package]]
+description = "CSS selectors for Python ElementTree"
+conda-forge = "cssselect2"
+pypi = "cssselect2"
+
+
+[[package]]
+description = "A CSS Cascading Style Sheets library for Python"
+conda-forge = "cssutils"
+pypi = "cssutils"
+
+
+[[package]]
+description = "A suite of command-line tools for working with CSV, the king of tabular file formats."
+conda-forge = "csvkit"
+pypi = "csvkit"
+
+
+[[package]]
+description = "Tools to load hydrographic data formats as pandas DataFrames."
+conda-forge = "ctd"
+pypi = "ctd"
+
+
+[[package]]
+description = "DB API 2.0-compliant Linux driver for SQL Server"
+conda-forge = "ctds"
+pypi = "ctds"
+
+
+[[package]]
+description = "Python interface for inspecting and running CLI modules (as defined by CommonTK)"
+conda-forge = "ctk-cli"
+pypi = "ctk-cli"
+
+
+[[package]]
+description = "Productivity Tools for Plotly + Pandas"
+conda-forge = "cufflinks-py"
+pypi = "cufflinks"
+
+
+[[package]]
+description = "The coroutine concurrency library."
+conda-forge = "curio"
+pypi = "curio"
+
+
+[[package]]
+description = "Online video processing in jupyter notebooks"
+conda-forge = "cvloop"
+pypi = "cvloop"
+
+
+[[package]]
+description = "Convex optimization package"
+conda-forge = "cvxopt"
+pypi = "cvxopt"
+
+
+[[package]]
+description = "A Python-embedded modeling language for convex optimization problems"
+conda-forge = "cvxpy"
+pypi = "cvxpy"
+
+
+[[package]]
+description = "Pandas extension array for IP and MAC addresses."
+conda-forge = "cyberpandas"
+pypi = "cyberpandas"
+
+
+[[package]]
+description = "Cython based KD-Tree"
+conda-forge = "cykdtree"
+pypi = "cykdtree"
+
+
+[[package]]
+description = "Manage calls to calloc/free through Cython"
+conda-forge = "cymem"
+pypi = "cymem"
+
+
+[[package]]
+description = "A minmax implementation in Cython for use with NumPy"
+conda-forge = "cyminmax"
+pypi = "cyminmax"
+
+
+[[package]]
+description = "Cython implementation of Python's collections.OrderedDict."
+conda-forge = "cyordereddict"
+pypi = "cyordereddict"
+
+
+[[package]]
+description = "CythonGSL provides a Cython interface for the GNU Scientific Library (GSL)."
+conda-forge = "cythongsl"
+pypi = "CythonGSL"
+
+
+[[package]]
+description = "The Cython compiler for writing C extensions for the Python language"
+conda-forge = "cython"
+pypi = "Cython"
+
+
+[[package]]
+description = "Cython implementation of Toolz. High performance functional utilities."
+conda-forge = "cytoolz"
+pypi = "cytoolz"
+
+
+[[package]]
+description = "Allows using distutils2-like setup.cfg files for a package's metadata with a distribute/setuptools setup.py"
+conda-forge = "d2to1"
+pypi = "d2to1"
+
+
+[[package]]
+description = "Dash UI core component suite"
+conda-forge = "dash-core-components"
+pypi = "dash-core-components"
+
+
+[[package]]
+description = "Dash UI HTML component suite"
+conda-forge = "dash-html-components"
+pypi = "dash-html-components"
+
+
+[[package]]
+description = "A Python framework for building reactive web-apps."
+conda-forge = "dash"
+pypi = "dash"
+
+
+[[package]]
+description = "Front-end component renderer for dash"
+conda-forge = "dash-renderer"
+pypi = "dash-renderer"
+
+
+[[package]]
+description = "Parallel Python with task scheduling"
+conda-forge = "dask-core"
+pypi = "dask"
+
+
+[[package]]
+description = "Distance computations with Dask (akin to scipy.spatial.distance)"
+conda-forge = "dask-distance"
+pypi = "dask-distance"
+
+
+[[package]]
+description = "Dask on DRMAA"
+conda-forge = "dask-drmaa"
+pypi = "dask-drmaa"
+
+
+[[package]]
+description = "Composable keyword function graphs"
+conda-forge = "dask-funk"
+pypi = "dask-funk"
+
+
+[[package]]
+description = "Generalized Linear Models in Dask"
+conda-forge = "dask-glm"
+pypi = "dask-glm"
+
+
+[[package]]
+description = "A library for loading image data into Dask"
+conda-forge = "dask-imread"
+pypi = "dask-imread"
+
+
+[[package]]
+description = "Easy deployment of Dask Distributed on job queuing systems like PBS, Slurm, and SGE."
+conda-forge = "dask-jobqueue"
+pypi = "dask-jobqueue"
+
+
+[[package]]
+description = "Native Kubernetes integration for Dask"
+conda-forge = "dask-kubernetes"
+pypi = "dask-kubernetes"
+
+
+[[package]]
+description = "Distributed and parallel machine learning using dask."
+conda-forge = "dask-ml"
+pypi = "dask-ml"
+
+
+[[package]]
+description = "A library for using N-D filters with Dask Arrays"
+conda-forge = "dask-ndfilters"
+pypi = "dask-ndfilters"
+
+
+[[package]]
+description = "A library for using N-D Fourier filter with Dask Arrays"
+conda-forge = "dask-ndfourier"
+pypi = "dask-ndfourier"
+
+
+[[package]]
+description = "A library for computing N-D measurements on labeled Dask Arrays"
+conda-forge = "dask-ndmeasure"
+pypi = "dask-ndmeasure"
+
+
+[[package]]
+description = "A library of N-D morphological operations for Dask Arrays"
+conda-forge = "dask-ndmorph"
+pypi = "dask-ndmorph"
+
+
+[[package]]
+description = "Tools for doing hyperparameter search with Scikit-Learn and Dask"
+conda-forge = "dask-searchcv"
+pypi = "dask-searchcv"
+
+
+[[package]]
+description = "Interactions between Dask and Tensorflow"
+conda-forge = "dask-tensorflow"
+pypi = "dask-tensorflow"
+
+
+[[package]]
+description = "Launch, train, and test with XGBoost from Dask"
+conda-forge = "dask-xgboost"
+pypi = "dask-xgboost"
+
+
+[[package]]
+description = "Deploy dask clusters on Apache YARN"
+conda-forge = "dask-yarn"
+pypi = "dask-yarn"
+
+
+[[package]]
+description = "Helpers for transparently downloading datasets"
+conda-forge = "datacache"
+pypi = "datacache"
+
+
+[[package]]
+description = "An implementation of PEP 557: Data Classes"
+conda-forge = "dataclasses"
+pypi = "dataclasses"
+
+
+[[package]]
+description = "The Datadog Python library"
+conda-forge = "datadog"
+pypi = "datadog"
+
+
+[[package]]
+description = "Python library for data.world"
+conda-forge = "datadotworld-py"
+pypi = "datadotworld"
+
+
+[[package]]
+description = "data distribution geared toward scientific datasets"
+conda-forge = "datalad"
+pypi = "datalad"
+
+
+[[package]]
+description = "Utilities to work with Data Packages as defined on dataprotocols.org"
+conda-forge = "datapackage-py"
+pypi = "datapackage"
+
+
+[[package]]
+description = "This client library is designed to support the DataRobot API."
+conda-forge = "datarobot"
+pypi = "datarobot"
+
+
+[[package]]
+description = "Data visualization toolchain based on aggregating into a grid"
+conda-forge = "datashader"
+pypi = "datashader"
+
+
+[[package]]
+description = "Date parsing library designed to parse dates from HTML pages."
+conda-forge = "dateparser"
+pypi = "dateparser"
+
+
+[[package]]
+description = "persistent, pythonic trees for heterogeneous data"
+conda-forge = "datreant.core"
+pypi = "datreant.core"
+
+
+[[package]]
+description = "persistent, pythonic trees for heterogeneous data"
+conda-forge = "datreant.data"
+pypi = "datreant.data"
+
+
+[[package]]
+description = "DAFSA-based dictionary-like read-only objects for Python"
+conda-forge = "dawg"
+pypi = "DAWG"
+
+
+[[package]]
+description = "read data from dbf files"
+conda-forge = "dbfread"
+pypi = "dbfread"
+
+
+[[package]]
+description = "Pure python package for reading/writing dBase, FoxPro, and Visual FoxPro .dbf files (including memos)"
+conda-forge = "dbf"
+pypi = "dbf"
+
+
+[[package]]
+description = "Distributed Evolutionary Algorithms in Python"
+conda-forge = "deap"
+pypi = "deap"
+
+
+[[package]]
+description = "A collection of Python deprecation patterns and strategies that help you collect your technical debt in a non-destructive manner."
+conda-forge = "debtcollector"
+pypi = "debtcollector"
+
+
+[[package]]
+description = "Start a cluster in EC2 for dask.distributed"
+conda-forge = "dask-ec2"
+pypi = "dask-ec2"
+
+
+[[package]]
+description = "Better living through Python with decorators."
+conda-forge = "decorator"
+pypi = "decorator"
+
+
+[[package]]
+description = "A configuration engine for Python frameworks"
+conda-forge = "dectate"
+pypi = "dectate"
+
+
+[[package]]
+description = "Deep Difference and Search of any Python object/data."
+conda-forge = "deepdiff"
+pypi = "deepdiff"
+
+
+[[package]]
+description = "Analyze Data with Pandas-based Networks."
+conda-forge = "deepgraph"
+pypi = "DeepGraph"
+
+
+[[package]]
+description = "XML bomb protection for Python stdlib modules"
+conda-forge = "defusedxml"
+pypi = "defusedxml"
+
+
+[[package]]
+description = "Subprocesses for Humans 2.0."
+conda-forge = "delegator"
+pypi = "delegator.py"
+
+
+[[package]]
+description = "Find all the unique imports in your library"
+conda-forge = "depfinder"
+pypi = "depfinder"
+
+
+[[package]]
+description = "Python @deprecated decorator to deprecate old python classes, functions or methods."
+conda-forge = "deprecated"
+pypi = "Deprecated"
+
+
+[[package]]
+description = "A library to handle automated deprecations"
+conda-forge = "deprecation"
+pypi = "deprecation"
+
+
+[[package]]
+description = "Descartes Labs Python Library"
+conda-forge = "descarteslabs"
+pypi = "descarteslabs"
+
+
+[[package]]
+description = "Use geometric objects as matplotlib paths and patches"
+conda-forge = "descartes"
+pypi = "descartes"
+
+
+[[package]]
+description = "Open source library for for interactive multiobjective optimization"
+conda-forge = "desdeo"
+pypi = "desdeo"
+
+
+[[package]]
+description = "Simple desktop integration for Python."
+conda-forge = "desktop3"
+pypi = "desktop3"
+
+
+[[package]]
+description = "Manage Google Spreadsheets in Pandas DataFrame with Python"
+conda-forge = "df2gspread"
+pypi = "df2gspread"
+
+
+[[package]]
+description = "small library to show simple dialogs to the user, without the need for a heavy GUI toolkit."
+conda-forge = "dialite"
+pypi = "dialite"
+
+
+[[package]]
+description = "Converts a Python dictionary or other native data type into a valid XML string. "
+conda-forge = "dicttoxml"
+pypi = "dicttoxml"
+
+
+[[package]]
+description = "The Diff Match and Patch libraries offer robust algorithms to perform the operations required for synchronizing plain text."
+conda-forge = "diff-match-patch"
+pypi = "diff-match-patch"
+
+
+[[package]]
+description = "in-depth comparison of files, archives, and directories"
+conda-forge = "diffoscope"
+pypi = "diffoscope"
+
+
+[[package]]
+description = "Serialize all of python (almost)"
+conda-forge = "dill"
+pypi = "dill"
+
+
+[[package]]
+description = "Library for computing persistent homology"
+conda-forge = "dionysus"
+pypi = "dionysus"
+
+
+[[package]]
+description = "Reading and analysing OOMMF odt files"
+conda-forge = "discretisedfield"
+pypi = "discretisedfield"
+
+
+[[package]]
+description = "Disk and file backed cache."
+conda-forge = "diskcache"
+pypi = "diskcache"
+
+
+[[package]]
+description = "Distributed computing with Dask"
+conda-forge = "distributed"
+pypi = "distributed"
+
+
+[[package]]
+description = "Linux Distribution - a Linux OS platform information API"
+conda-forge = "distro"
+pypi = "distro"
+
+
+[[package]]
+description = "Edit ForeignKey, ManyToManyField and CharField in Django Admin using jQuery UI AutoComplete."
+conda-forge = "django-ajax-selects"
+pypi = "django-ajax-selects"
+
+
+[[package]]
+description = "Integrated set of Django applications addressing authentication, registration, account management as well as 3rd party (social) account authentication"
+conda-forge = "django-allauth"
+pypi = "django-allauth"
+
+
+[[package]]
+description = "Django email backends and webhooks for Mailgun, Mailjet, Postmark, SendGrid, SparkPost and more "
+conda-forge = "django-anymail"
+pypi = "django-anymail"
+
+
+[[package]]
+description = "An app to handle configuration defaults of packaged Django apps gracefully"
+conda-forge = "django-appconf"
+pypi = "django-appconf"
+
+
+[[package]]
+description = "Django template loader that allows you to load and override a template from a specific Django application."
+conda-forge = "django-apptemplates"
+pypi = "django-apptemplates"
+
+
+[[package]]
+description = "An automated slug field for Django"
+conda-forge = "django-autoslug"
+pypi = "django-autoslug"
+
+
+[[package]]
+description = "A set of helpers for baking your Django site out as flat files"
+conda-forge = "django-bakery"
+pypi = "django-bakery"
+
+
+[[package]]
+description = "Bootstrap 3 integration with Django."
+conda-forge = "django-bootstrap3"
+pypi = "django-bootstrap3"
+
+
+[[package]]
+description = "Bootstrap 4 integration with Django."
+conda-forge = "django-bootstrap4"
+pypi = "django-bootstrap4"
+
+
+[[package]]
+description = "Reusable, generic mixins for Django "
+conda-forge = "django-braces"
+pypi = "django-braces"
+
+
+[[package]]
+description = "No effort, no worry, maximum performance. "
+conda-forge = "django-cachalot"
+pypi = "django-cachalot"
+
+
+[[package]]
+description = "Upload large files to Django in multiple chunks, with the ability to resume if the upload is interrupted."
+conda-forge = "django-chunked-upload"
+pypi = "django-chunked-upload"
+
+
+[[package]]
+description = "Adds pretty CSS styles for the django CMS admin interface."
+conda-forge = "djangocms-admin-style"
+pypi = "djangocms-admin-style"
+
+
+[[package]]
+description = "Compresses linked and inline javascript or CSS into a single cached file."
+conda-forge = "django_compressor"
+pypi = "django_compressor"
+
+
+[[package]]
+description = "A helper for organizing Django project settings by relying on well established programming patterns.  "
+conda-forge = "django-configurations"
+pypi = "django-configurations"
+
+
+[[package]]
+description = "A plugin for coverage.py to measure Django template execution"
+conda-forge = "django_coverage_plugin"
+pypi = "django_coverage_plugin"
+
+
+[[package]]
+description = "The best way to have DRY Django forms. The app provides a tag and filter that lets you quickly render forms in a div format while providing an enormous amount of capability to configure and control the rendered HTML."
+conda-forge = "django-crispy-forms"
+pypi = "django-crispy-forms"
+
+
+[[package]]
+description = "django-cruds is simple drop-in django app that creates CRUD for faster prototyping"
+conda-forge = "django-cruds-adminlte"
+pypi = "django-cruds-adminlte"
+
+
+[[package]]
+description = "Allow to filter by a custom date range on the Django Admin"
+conda-forge = "django-daterange-filter"
+pypi = "django-daterange-filter"
+
+
+[[package]]
+description = "A configurable set of panels that display various debug information about the current request/response."
+conda-forge = "django-debug-toolbar"
+pypi = "django-debug-toolbar"
+
+
+[[package]]
+description = "Django-environ allows you to utilize 12factor inspired environment variables to configure your Django application."
+conda-forge = "django-environ"
+pypi = "django-environ"
+
+
+[[package]]
+description = "Extensions for Django."
+conda-forge = "django-extensions"
+pypi = "django-extensions"
+
+
+[[package]]
+description = "File and Image Management Application for django"
+conda-forge = "django-filer"
+pypi = "django-filer"
+
+
+[[package]]
+description = "A few extra management tools to handle fixtures."
+conda-forge = "django-fixture-magic"
+pypi = "django-fixture-magic"
+
+
+[[package]]
+description = "Template tags for woking with Zurb Foundation Forms in your Django projects "
+conda-forge = "django-foundation-formtags"
+pypi = "django-foundation-formtags"
+
+
+[[package]]
+description = "Django friendly finite state machine support"
+conda-forge = "django-fsm"
+pypi = "django-fsm"
+
+
+[[package]]
+description = "A jazzy skin for the Django Admin-Interface."
+conda-forge = "django-grappelli"
+pypi = "django-grappelli"
+
+
+[[package]]
+description = "Per object permissions for Django"
+conda-forge = "django-guardian"
+pypi = "django-guardian"
+
+
+[[package]]
+description = "Modular search for Django"
+conda-forge = "django-haystack"
+pypi = "django-haystack"
+
+
+[[package]]
+description = "Django application and library for importing and exporting data with included admin integration."
+conda-forge = "django-import-export"
+pypi = "django-import-export"
+
+
+[[package]]
+description = "jQuery packaged in an handy django app to speed up new applications and deployment."
+conda-forge = "django-jquery"
+pypi = "django-jquery"
+
+
+[[package]]
+description = "script tag with additional attributes for django.forms.Media"
+conda-forge = "django-js-asset"
+pypi = "django-js-asset"
+
+
+[[package]]
+description = "Django JSON Editor"
+conda-forge = "django-jsoneditor"
+pypi = "0164e082b29777fbc56c2373b68da93d23a29a040787e7f1c65e1562f133"
+
+
+[[package]]
+description = "django-leaflet allows you to use Leaflet in your Django projects."
+conda-forge = "django-leaflet"
+pypi = "django-leaflet"
+
+
+[[package]]
+description = "A django-compressor filter to compile SASS files using libsass"
+conda-forge = "django-libsass"
+pypi = "django-libsass"
+
+
+[[package]]
+description = "makemessages command that allows for arguments to be passed to xgettext."
+conda-forge = "django-makemessages-xgettext"
+pypi = "django-makemessages-xgettext"
+
+
+[[package]]
+description = "Material Design for django forms and admin"
+conda-forge = "django-material"
+pypi = "django-material"
+
+
+[[package]]
+description = "Django extension to allow working with clusters of models as a single unit, independently of the database"
+conda-forge = "django-modelcluster"
+pypi = "django-modelcluster"
+
+
+[[package]]
+description = "Django model mixins and utilities."
+conda-forge = "django-model-utils"
+pypi = "django-model-utils"
+
+
+[[package]]
+description = "Django-mptt-admin provides a nice Django Admin interface for Mptt models"
+conda-forge = "django-mptt-admin"
+pypi = "django-mptt-admin"
+
+
+[[package]]
+description = "Utilities for implementing a modified pre-order traversal tree in django."
+conda-forge = "django-mptt"
+pypi = "django-mptt"
+
+
+[[package]]
+description = "Mustache (Pystache) template engine for Django 1.8 and newer, with support for Django context processors. Designed to support offline-capable web apps via progressive enhancement."
+conda-forge = "django-mustache"
+pypi = "django-mustache"
+
+
+[[package]]
+description = "Makes your Django tests simple and snappy"
+conda-forge = "django-nose"
+pypi = "django-nose"
+
+
+[[package]]
+description = "Tools for working with pandas in your Django projects"
+conda-forge = "django-pandas"
+pypi = "django-pandas"
+
+
+[[package]]
+description = "A high-level Python Web framework that encourages rapid development and clean, pragmatic design."
+conda-forge = "django"
+pypi = "Django"
+
+
+[[package]]
+description = "Redis Cache Backend for Django"
+conda-forge = "django-redis-cache"
+pypi = "django-redis-cache"
+
+
+[[package]]
+description = "Full featured redis cache backend for Django"
+conda-forge = "django-redis"
+pypi = "django-redis"
+
+
+[[package]]
+description = "CSV Tools for Django REST Framework"
+conda-forge = "djangorestframework-csv"
+pypi = "djangorestframework-csv"
+
+
+[[package]]
+description = "Geographic add-ons for Django Rest Framework"
+conda-forge = "djangorestframework-gis"
+pypi = "djangorestframework-gis"
+
+
+[[package]]
+description = "JSON Web Token Authentication support for Django REST Framework"
+conda-forge = "djangorestframework-jwt"
+pypi = "djangorestframework-jwt"
+
+
+[[package]]
+description = "Web APIs for Django, made easy"
+conda-forge = "djangorestframework"
+pypi = "djangorestframework"
+
+
+[[package]]
+description = "A JSON Web Token authentication plugin for the Django REST Framework."
+conda-forge = "djangorestframework_simplejwt"
+pypi = "djangorestframework_simplejwt"
+
+
+[[package]]
+description = "XML support for Django REST Framework"
+conda-forge = "djangorestframework-xml"
+pypi = "djangorestframework-xml"
+
+
+[[package]]
+description = "YAML support for Django REST Framework"
+conda-forge = "djangorestframework-yaml"
+pypi = "djangorestframework-yaml"
+
+
+[[package]]
+description = "A powerful mechanism for sending real time API notifications via a new subscription model."
+conda-forge = "django-rest-hooks"
+pypi = "django-rest-hooks"
+
+
+[[package]]
+description = "Add compare view to django-reversion for comparing two versions of a reversion model."
+conda-forge = "django-reversion-compare"
+pypi = "django-reversion-compare"
+
+
+[[package]]
+description = "django-reversion is an extension to the Django web framework that provides version control for model instances."
+conda-forge = "django-reversion"
+pypi = "django-reversion"
+
+
+[[package]]
+description = "A simple app that provides django integration for RQ (Redis Queue)"
+conda-forge = "django-rq"
+pypi = "django-rq"
+
+
+[[package]]
+description = "Store model history and view/revert changes from admin site."
+conda-forge = "django-simple-history"
+pypi = "django-simple-history"
+
+
+[[package]]
+description = "django-storages is a project to provide a variety of storage backends in a single library."
+conda-forge = "django-storages"
+pypi = "django-storages"
+
+
+[[package]]
+description = "django-storages is a project to provide a variety of storage backends in a single library."
+conda-forge = "django-storages-redux"
+pypi = "django-storages-redux"
+
+
+[[package]]
+description = "Useful additions to Django default TestCase"
+conda-forge = "django-test-plus"
+pypi = "django-test-plus"
+
+
+[[package]]
+description = "Efficient tree implementations for Django"
+conda-forge = "django-treebeard"
+pypi = "django-treebeard"
+
+
+[[package]]
+description = "Sane single table model inheritance for Django."
+conda-forge = "django-typed-models"
+pypi = "django-typed-models"
+
+
+[[package]]
+description = "A django utility that creates unique file names for uploaded files via uuids."
+conda-forge = "django-unique-upload"
+pypi = "django-unique-upload"
+
+
+[[package]]
+description = "A drop-in replacement for django ImageField that provides a flexible, intuitive and easily-extensible interface for quickly creating new images from the one assigned to the field."
+conda-forge = "django-versatileimagefield"
+pypi = "django-versatileimagefield"
+
+
+[[package]]
+description = "Reusable workflow library for Django"
+conda-forge = "django-viewflow"
+pypi = "django-viewflow"
+
+
+[[package]]
+description = "Adds support for RSS and JSON Feeds to your Wagtail CMS Projects"
+conda-forge = "django-wagtail-feeds"
+pypi = "django-wagtail-feeds"
+
+
+[[package]]
+description = "Tweak the form field rendering in templates, not in python-level form definitions."
+conda-forge = "django-widget-tweaks"
+pypi = "django-widget-tweaks"
+
+
+[[package]]
+description = "Use Database URLs in your Django Application."
+conda-forge = "dj-database-url"
+pypi = "dj-database-url"
+
+
+[[package]]
+description = "Serve production static files with Django."
+conda-forge = "dj-static"
+pypi = "dj-static"
+
+
+[[package]]
+description = "DNS toolkit"
+conda-forge = "dnspython"
+pypi = "dnspython"
+
+
+[[package]]
+description = "Convert docs to Dash.app"
+conda-forge = "doc2dash"
+pypi = "doc2dash"
+
+
+[[package]]
+description = "Doc8 is an opinionated style checker for rst (with basic support for plain text) styles of documentation."
+conda-forge = "doc8"
+pypi = "doc8"
+
+
+[[package]]
+description = "Pythonic argument parser, that will make you smile"
+conda-forge = "docopt"
+pypi = "docopt"
+
+
+[[package]]
+description = "Python package for docstring repetition"
+conda-forge = "docrep"
+pypi = "docrep"
+
+
+[[package]]
+description = "Deploy docs from Travis to GitHub pages."
+conda-forge = "doctr"
+pypi = "doctr"
+
+
+[[package]]
+description = "Docutils -- Python Documentation Utilities"
+conda-forge = "docutils"
+pypi = "docutils"
+
+
+[[package]]
+description = "A pure python-based utility to extract text and images from docx files."
+conda-forge = "docx2txt"
+pypi = "docx2txt"
+
+
+[[package]]
+description = "Dodgy: Searches for dodgy looking lines in Python code"
+conda-forge = "dodgy"
+pypi = "dodgy"
+
+
+[[package]]
+description = "A caching front-end based on the Dogpile lock."
+conda-forge = "dogpile.cache"
+pypi = "dogpile.cache"
+
+
+[[package]]
+description = "doit - Automation Tool"
+conda-forge = "doit"
+pypi = "doit"
+
+
+[[package]]
+description = "Doppler Ocean Library for pYthoN."
+conda-forge = "dolfyn"
+pypi = "dolfyn"
+
+
+[[package]]
+description = "Dominate is a Python library for creating and manipulating HTML documents using an elegant DOM API."
+conda-forge = "dominate"
+pypi = "dominate"
+
+
+[[package]]
+description = "Ordered, dynamically-expandable dot-access dictionary"
+conda-forge = "dotmap"
+pypi = "dotmap"
+
+
+[[package]]
+description = "Python wrapper for C++ Double Metaphone"
+conda-forge = "doublemetaphone"
+pypi = "DoubleMetaphone"
+
+
+[[package]]
+description = "Filesystem-like pathing and searching for dictionaries"
+conda-forge = "dpath"
+pypi = "dpath"
+
+
+[[package]]
+description = "Library to convert Draft.js ContentState to HTML"
+conda-forge = "draftjs_exporter"
+pypi = "draftjs_exporter"
+
+
+[[package]]
+description = "Haystack for Django REST Framework"
+conda-forge = "drf-haystack"
+pypi = "drf-haystack"
+
+
+[[package]]
+description = "Python wrapper around the C DRMAA library."
+conda-forge = "drmaa"
+pypi = "drmaa"
+
+
+[[package]]
+description = "Access HMI, AIA and MDI data with Python"
+conda-forge = "drms"
+pypi = "drms"
+
+
+[[package]]
+description = "Official Dropbox API Client"
+conda-forge = "dropbox"
+pypi = "dropbox"
+
+
+[[package]]
+description = "Local Interpretable Model-Agnostic Explanations (DataScience.com fork)"
+conda-forge = "ds-lime"
+pypi = "ds-lime"
+
+
+[[package]]
+description = "Python Git Library"
+conda-forge = "dulwich"
+pypi = "dulwich"
+
+
+[[package]]
+description = "A Python library to grab information from DXF drawings - all DXF versions supported."
+conda-forge = "dxfgrabber"
+pypi = "dxfgrabber"
+
+
+[[package]]
+description = "Various tools for theoretical and experimental dynamics."
+conda-forge = "dynamicisttoolkit"
+pypi = "DynamicistToolKit"
+
+
+[[package]]
+description = "A dynamic nested sampling package for computing Bayesian posteriors and evidences."
+conda-forge = "dynesty"
+pypi = "dynesty"
+
+
+[[package]]
+description = "Earth Engine Python API"
+conda-forge = "earthengine-api"
+pypi = "earthengine-api"
+
+
+[[package]]
+description = "Making argument parsing easy"
+conda-forge = "easyargs"
+pypi = "easyargs"
+
+
+[[package]]
+description = "Common utilities to ease the development of Python packages"
+conda-forge = "easydev"
+pypi = "easydev"
+
+
+[[package]]
+description = "Easy thumbnails for Django"
+conda-forge = "easy-thumbnails"
+pypi = "easy-thumbnails"
+
+
+[[package]]
+description = "Dead-simple way to watch a directory"
+conda-forge = "easywatch"
+pypi = "easywatch"
+
+
+[[package]]
+description = "Ebook library which can handle EPUB2/EPUB3 and Kindle format"
+conda-forge = "ebooklib"
+pypi = "EbookLib"
+
+
+[[package]]
+description = "Python interface for ECOS, a lightweight conic solver for second-order cone programming"
+conda-forge = "ecos"
+pypi = "ecos"
+
+
+[[package]]
+description = "Computing edit distance on arbitrary Python sequences."
+conda-forge = "edit_distance"
+pypi = "edit_distance"
+
+
+[[package]]
+description = "Fast implementation of the edit distance(Levenshtein distance)"
+conda-forge = "editdistance"
+pypi = "editdistance"
+
+
+[[package]]
+description = "Eight is a Python module that provides a minimalist compatibility layer between Python 3 and 2"
+conda-forge = "eight"
+pypi = "eight"
+
+
+[[package]]
+description = "Elastic is a set of python routines for calculation of elastic properties of crystals"
+conda-forge = "elastic"
+pypi = "elastic"
+
+
+[[package]]
+description = "Async backend for elasticsearch-py"
+conda-forge = "elasticsearch-async"
+pypi = "elasticsearch-async"
+
+
+[[package]]
+description = "Higher-level Python client for Elasticsearch"
+conda-forge = "elasticsearch-dsl"
+pypi = "elasticsearch-dsl"
+
+
+[[package]]
+description = "Python client for Elasticsearch"
+conda-forge = "elasticsearch"
+pypi = "elasticsearch"
+
+
+[[package]]
+description = "A highly configurable toolkit for training 3d/2d CNNs and general Neural Networks"
+conda-forge = "elektronn2"
+pypi = "elektronn2"
+
+
+[[package]]
+description = "XPath 1.0/2.0 parsers and selectors for ElementTree"
+conda-forge = "elementpath"
+pypi = "elementpath"
+
+
+[[package]]
+description = "Debug machine learning classifiers and explain their predictions"
+conda-forge = "eli5"
+pypi = "eli5"
+
+
+[[package]]
+description = "A robust email syntax and deliverability validation library for Python 2.x/3.x."
+conda-forge = "email_validator"
+pypi = "email_validator"
+
+
+[[package]]
+description = "Kick ass affine-invariant ensemble MCMC sampling"
+conda-forge = "emcee"
+pypi = "emcee"
+
+
+[[package]]
+description = "analyze text with empath"
+conda-forge = "empath"
+pypi = "empath"
+
+
+[[package]]
+description = "Emperor a tool for the analysis and visualization of large microbial ecology datasets"
+conda-forge = "emperor"
+pypi = "emperor"
+
+
+[[package]]
+description = "Common financial risk metrics"
+conda-forge = "empyrical"
+pypi = "empyrical"
+
+
+[[package]]
+description = "Declarative DSL for building rich user interfaces in Python"
+conda-forge = "enaml"
+pypi = "enaml"
+
+
+[[package]]
+description = "A python package for defensive data analysis."
+conda-forge = "engarde"
+pypi = "engarde"
+
+
+[[package]]
+description = "Discover and load entry points from installed packages"
+conda-forge = "entrypoints"
+pypi = "entrypoints"
+
+
+[[package]]
+description = "extensible application framework"
+conda-forge = "envisage"
+pypi = "envisage"
+
+
+[[package]]
+description = "EOF analysis in Python"
+conda-forge = "eofs"
+pypi = "eofs"
+
+
+[[package]]
+description = "Basic astronomical computations for Python"
+conda-forge = "ephem"
+pypi = "ephem"
+
+
+[[package]]
+description = "Detection and analysis of repeating and near-repeating earthquakes"
+conda-forge = "eqcorrscan"
+pypi = "EQcorrscan"
+
+
+[[package]]
+description = "Python interface for ERDDAP"
+conda-forge = "erddapy"
+pypi = "erddapy"
+
+
+[[package]]
+description = "Fitting thermodynamic models with pycalphad."
+conda-forge = "espei"
+pypi = "espei"
+
+
+[[package]]
+description = "An implementation of lxml.xmlfile for the standard library"
+conda-forge = "et_xmlfile"
+pypi = "et_xmlfile"
+
+
+[[package]]
+description = "Idiomatic access to the eXist-db XML Database using XPath and XQuery"
+conda-forge = "eulexistdb"
+pypi = "eulexistdb"
+
+
+[[package]]
+description = "XPath-based XML data binding"
+conda-forge = "eulxml"
+pypi = "eulxml"
+
+
+[[package]]
+description = "Highly concurrent networking library"
+conda-forge = "eventlet"
+pypi = "eventlet"
+
+
+[[package]]
+description = "Python Event Handling the C# Style"
+conda-forge = "events"
+pypi = "Events"
+
+
+[[package]]
+description = "distributed Python deployment and communication"
+conda-forge = "execnet"
+pypi = "execnet"
+
+
+[[package]]
+description = "command line tool to create wrappers around executables"
+conda-forge = "exec-wrappers"
+pypi = "exec-wrappers"
+
+
+[[package]]
+description = "Read Exif metadata from tiff and jpeg files."
+conda-forge = "exifread"
+pypi = "ExifRead"
+
+
+[[package]]
+description = "Fast interstellar dust extinction laws"
+conda-forge = "extinction"
+pypi = "extinction"
+
+
+[[package]]
+description = "Useful extra bits for Python - things that shold be in the standard library"
+conda-forge = "extras"
+pypi = "extras"
+
+
+[[package]]
+description = "A Python package to create/manipulate DXF drawings."
+conda-forge = "ezdxf"
+pypi = "ezdxf"
+
+
+[[package]]
+description = "A Python package to create/manipulate OpenDocumentFormat files."
+conda-forge = "ezodf"
+pypi = "ezodf"
+
+
+[[package]]
+description = "ez_setup.py and distribute_setup.py"
+conda-forge = "ez_setup"
+pypi = "ez_setup"
+
+
+[[package]]
+description = "Fortran 90 namelist parser"
+conda-forge = "f90nml"
+pypi = "f90nml"
+
+
+[[package]]
+description = "Fabric is a simple, Pythonic tool for remote execution and deployment (py2.7/py3.4+ compatible fork)."
+conda-forge = "fabric3"
+pypi = "Fabric3"
+
+
+[[package]]
+description = "A versatile test fixtures replacement based on thoughtbot's factory_girl for Ruby."
+conda-forge = "factory_boy"
+pypi = "factory_boy"
+
+
+[[package]]
+description = "Faker is a Python package that generates fake data for you."
+conda-forge = "fake-factory"
+pypi = "fake-factory"
+
+
+[[package]]
+description = "Faker is a Python package that generates fake data for you."
+conda-forge = "faker"
+pypi = "Faker"
+
+
+[[package]]
+description = "colorful Python TAB completion"
+conda-forge = "fancycompleter"
+pypi = "fancycompleter"
+
+
+[[package]]
+description = "C implementation of Python 3 lru_cache"
+conda-forge = "fastcache"
+pypi = "fastcache"
+
+
+[[package]]
+description = "Fast hierarchical clustering routines for R and Python."
+conda-forge = "fastcluster"
+pypi = "fastcluster"
+
+
+[[package]]
+description = "A python package that provides useful locks."
+conda-forge = "fasteners"
+pypi = "fasteners"
+
+
+[[package]]
+description = "Fast 1D and 2D histogram functions in Python"
+conda-forge = "fast-histogram"
+pypi = "fast-histogram"
+
+
+[[package]]
+description = "VCS fastimport/fastexport parser"
+conda-forge = "fastimport"
+pypi = "fastimport"
+
+
+[[package]]
+description = "Super-fast and clean conversions to numbers."
+conda-forge = "fastnumbers"
+pypi = "fastnumbers"
+
+
+[[package]]
+description = "Python interface to the parquet format"
+conda-forge = "fastparquet"
+pypi = "fastparquet"
+
+
+[[package]]
+description = "A fault localization tool for Python's pytest testing framework."
+conda-forge = "fault-localization"
+pypi = "fault-localization"
+
+
+[[package]]
+description = "Automatic Forecasting Procedure"
+conda-forge = "fbprophet"
+pypi = "fbprophet"
+
+
+[[package]]
+description = "Feather: fast, interoperable binary data frame storage for Python, R, and more powered by Apache Arrow"
+conda-forge = "feather-format"
+pypi = "feather-format"
+
+
+[[package]]
+description = "Find the feed URLs for a website."
+conda-forge = "feedfinder2"
+pypi = "feedfinder2"
+
+
+[[package]]
+description = "Standalone version of django.utils.feedgenerator, compatible with Py3k"
+conda-forge = "feedgenerator"
+pypi = "feedgenerator"
+
+
+[[package]]
+description = "Fermipy is a python package for analysis of Fermi-LAT data"
+conda-forge = "fermipy"
+pypi = "fermipy"
+
+
+[[package]]
+description = "FileChunkIO represents a chunk of an OS-level file containing bytes data"
+conda-forge = "filechunkio"
+pypi = "filechunkio"
+
+
+[[package]]
+description = "A platform independent file lock."
+conda-forge = "filelock"
+pypi = "filelock"
+
+
+[[package]]
+description = "A simple tool for tracking files"
+conda-forge = "filesdb"
+pypi = "filesdb"
+
+
+[[package]]
+description = "Infer file type and MIME type of any file/buffer. No external dependencies."
+conda-forge = "filetype"
+pypi = "filetype"
+
+
+[[package]]
+description = "Kalman filters and other optimal and non-optimal estimation filters in Python"
+conda-forge = "filterpy"
+pypi = "filterpy"
+
+
+[[package]]
+description = "Find pyspark to make it importable."
+conda-forge = "findspark"
+pypi = "findspark"
+
+
+[[package]]
+description = "Finite difference weights for any derivative order on arbitrarily spaced grids"
+conda-forge = "finitediff"
+pypi = "finitediff"
+
+
+[[package]]
+description = "Python Fire is a library for creating command line interfaces (CLIs) from absolutely any Python object."
+conda-forge = "fire"
+pypi = "fire"
+
+
+[[package]]
+description = "A Cyclus batch execution service"
+conda-forge = "fixie-batch"
+pypi = "fixie-batch"
+
+
+[[package]]
+description = "A Cyclus credentialing service"
+conda-forge = "fixie-creds"
+pypi = "fixie-creds"
+
+
+[[package]]
+description = "A Cyclus data managment service"
+conda-forge = "fixie-data"
+pypi = "fixie-data"
+
+
+[[package]]
+description = "Cyclus-as-a-Service"
+conda-forge = "fixie"
+pypi = "fixie"
+
+
+[[package]]
+description = "Fixtures, reusable state for writing clean tests and more."
+conda-forge = "fixtures"
+pypi = "fixtures"
+
+
+[[package]]
+description = "A flake8 extension that checks for blind, catch-all except statements"
+conda-forge = "flake8-blind-except"
+pypi = "flake8-blind-except"
+
+
+[[package]]
+description = "Check for python builtins being used as variables or parameters."
+conda-forge = "flake8-builtins"
+pypi = "flake8-builtins"
+
+
+[[package]]
+description = "A flake8 plugin that helps you write better list/set/dict comprehensions."
+conda-forge = "flake8-comprehensions"
+pypi = "flake8-comprehensions"
+
+
+[[package]]
+description = "Flake8 plugin to check for copyright notices in all python files."
+conda-forge = "flake8-copyright"
+pypi = "flake8-copyright"
+
+
+[[package]]
+description = "Extension for flake8 which uses pydocstyle to check docstrings"
+conda-forge = "flake8-docstrings"
+pypi = "flake8-docstrings"
+
+
+[[package]]
+description = "A flake8 and Pylama plugin that checks the ordering of your imports."
+conda-forge = "flake8-import-order"
+pypi = "flake8-import-order"
+
+
+[[package]]
+description = "Flake8 plugin to check against using mutable values as default arguments."
+conda-forge = "flake8-mutable"
+pypi = "flake8-mutable"
+
+
+[[package]]
+description = "Check for uses of old % formatting rather than .format() method"
+conda-forge = "flake8-pep3101"
+pypi = "flake8-pep3101"
+
+
+[[package]]
+description = "Provides some compatibility helpers for Flake8 plugins that intend to support Flake8 2.x and 3.x simultaneously."
+conda-forge = "flake8-polyfill"
+pypi = "flake8-polyfill"
+
+
+[[package]]
+description = "Flake8 plugin to check for print statements in python files."
+conda-forge = "flake8-print"
+pypi = "flake8-print"
+
+
+[[package]]
+description = "Flake8 lint for quotes."
+conda-forge = "flake8-quotes"
+pypi = "flake8-quotes"
+
+
+[[package]]
+description = "Your Tool For Style Guide Enforcement"
+conda-forge = "flake8"
+pypi = "flake8"
+
+
+[[package]]
+description = "Plugin for nose or py.test that automatically reruns flaky tests."
+conda-forge = "flaky"
+pypi = "flaky"
+
+
+[[package]]
+description = "Easy Swagger UI for your Flask API"
+conda-forge = "flasgger"
+pypi = "flasgger"
+
+
+[[package]]
+description = "Simple and extensible admin interface framework for Flask"
+conda-forge = "flask-admin"
+pypi = "Flask-Admin"
+
+
+[[package]]
+description = "authorization tool for Flask"
+conda-forge = "flask-allows"
+pypi = "flask-allows"
+
+
+[[package]]
+description = "Build and document REST APIs with Flask and apispec"
+conda-forge = "flask-apispec"
+pypi = "flask-apispec"
+
+
+[[package]]
+description = "Asset management for Flask, to compress and merge CSS and Javascript files."
+conda-forge = "flask-assets"
+pypi = "Flask-Assets"
+
+
+[[package]]
+description = "Generates index page like mod_autoindex"
+conda-forge = "flask-autoindex"
+pypi = "Flask-AutoIndex"
+
+
+[[package]]
+description = "Adds i18n/l10n support to Flask applications"
+conda-forge = "flask-babelex"
+pypi = "Flask-BabelEx"
+
+
+[[package]]
+description = "Adds i18n/l10n support to Flask applications"
+conda-forge = "flask-babel"
+pypi = "Flask-Babel"
+
+
+[[package]]
+description = "HTTP basic access authentication for Flask."
+conda-forge = "flask-basicauth"
+pypi = "Flask-BasicAuth"
+
+
+[[package]]
+description = "Bcrypt hashing for Flask."
+conda-forge = "flask-bcrypt"
+pypi = "flask-bcrypt"
+
+
+[[package]]
+description = "An extension to manage and serve your javascript assets with bower"
+conda-forge = "flask-bower"
+pypi = "Flask-Bower"
+
+
+[[package]]
+description = "Adds cache support to your Flask application"
+conda-forge = "flask-cache"
+pypi = "flask-cache"
+
+
+[[package]]
+description = "Flask-Celery-Helper doesn't break PyCharm autocomplete/inspections"
+conda-forge = "flask-celery-helper"
+pypi = "Flask-Celery-Helper"
+
+
+[[package]]
+description = "Compress responses in your Flask app with gzip."
+conda-forge = "flask-compress"
+pypi = "Flask-Compress"
+
+
+[[package]]
+description = "A Flask extension adding a decorator for CORS support"
+conda-forge = "flask-cors"
+pypi = "Flask-Cors"
+
+
+[[package]]
+description = "Provides utilities for using CouchDB with Flask"
+conda-forge = "flask-couchdb"
+pypi = "Flask-CouchDB"
+
+
+[[package]]
+description = "A toolbar overlay for debugging Flask applications."
+conda-forge = "flask-debugtoolbar"
+pypi = "Flask-DebugToolbar"
+
+
+[[package]]
+description = "A flask extension using pyexcel to read, manipulate and write data in different excel formats: csv, ods, xls, xlsx and xlsm."
+conda-forge = "flask-excel"
+pypi = "Flask-Excel"
+
+
+[[package]]
+description = "Provides flat static pages to a Flask application"
+conda-forge = "flask-flatpages"
+pypi = "Flask-FlatPages"
+
+
+[[package]]
+description = "An extension to Flask for easy Genshi templating."
+conda-forge = "flask-genshi"
+pypi = "Flask-Genshi"
+
+
+[[package]]
+description = "Basic and Digest HTTP authentication for Flask routes"
+conda-forge = "flask-httpauth"
+pypi = "Flask-HTTPAuth"
+
+
+[[package]]
+description = "A Flask extension adding a decorator for JSONP support"
+conda-forge = "flask-jsonpify"
+pypi = "Flask-Jsonpify"
+
+
+[[package]]
+description = "A Flask JWT extension"
+conda-forge = "flask-jwt-extended"
+pypi = "Flask-JWT-Extended"
+
+
+[[package]]
+description = "LDAP3 Logins for Flask/Flask-Login"
+conda-forge = "flask-ldap3-login"
+pypi = "flask-ldap3-login"
+
+
+[[package]]
+description = "User session management for Flask"
+conda-forge = "flask-login"
+pypi = "Flask-Login"
+
+
+[[package]]
+description = "Flask extension for sending email"
+conda-forge = "flask-mail"
+pypi = "flask-mail"
+
+
+[[package]]
+description = "Flask + marshmallow for beautiful APIs"
+conda-forge = "flask-marshmallow"
+pypi = "flask-marshmallow"
+
+
+[[package]]
+description = "SQLAlchemy database migrations for Flask applications using Alembic"
+conda-forge = "flask-migrate"
+pypi = "Flask-Migrate"
+
+
+[[package]]
+description = "Formatting of dates and times in Flask templates using moment.js."
+conda-forge = "flask-moment"
+pypi = "Flask-Moment"
+
+
+[[package]]
+description = "Easily create navigation for Flask applications."
+conda-forge = "flask-nav"
+pypi = "flask-nav"
+
+
+[[package]]
+description = "OAuthlib for Flask"
+conda-forge = "flask-oauthlib"
+pypi = "Flask-OAuthlib"
+
+
+[[package]]
+description = "OpenID support for Flask"
+conda-forge = "flask-openid"
+pypi = "Flask-OpenID"
+
+
+[[package]]
+description = "Identity management for flask"
+conda-forge = "flask-principal"
+pypi = "Flask-Principal"
+
+
+[[package]]
+description = "A microframework based on Werkzeug, Jinja2 and good intentions."
+conda-forge = "flask"
+pypi = "Flask"
+
+
+[[package]]
+description = "Flask-Redis-Helper doesn't break PyCharm autocomplete/inspections"
+conda-forge = "flask-redis-helper"
+pypi = "Flask-Redis-Helper"
+
+
+[[package]]
+description = "Simple framework for creating REST APIs"
+conda-forge = "flask-restful"
+pypi = "Flask-RESTful"
+
+
+[[package]]
+description = "A Flask extension for easy ReSTful API generation"
+conda-forge = "flask-restless"
+pypi = "Flask-Restless"
+
+
+[[package]]
+description = "Scripting support for Flask"
+conda-forge = "flask-script"
+pypi = "Flask-Script"
+
+
+[[package]]
+description = "An updated CSRF extension for Flask."
+conda-forge = "flask-seasurf"
+pypi = "Flask-SeaSurf"
+
+
+[[package]]
+description = "Simple security for Flask apps"
+conda-forge = "flask-security"
+pypi = "Flask-Security"
+
+
+[[package]]
+description = "Adds silk icons to your Flask application or blueprint, or extension"
+conda-forge = "flask-silk"
+pypi = "Flask-Silk"
+
+
+[[package]]
+description = "Socket.IO integration for Flask applications"
+conda-forge = "flask-socketio"
+pypi = "Flask-SocketIO"
+
+
+[[package]]
+description = "Adds SQLAlchemy support to your Flask application"
+conda-forge = "flask-sqlalchemy"
+pypi = "Flask-SQLAlchemy"
+
+
+[[package]]
+description = "Extract swagger specs from your flask project"
+conda-forge = "flask-swagger"
+pypi = "flask-swagger"
+
+
+[[package]]
+description = "Swagger UI blueprint for Flask"
+conda-forge = "flask-swagger-ui"
+pypi = "flask-swagger-ui"
+
+
+[[package]]
+description = "Unit testing for Flask"
+conda-forge = "flask-testing"
+pypi = "Flask-Testing"
+
+
+[[package]]
+description = "Turbolinks for Flask."
+conda-forge = "flask-turbolinks"
+pypi = "Flask-Turbolinks"
+
+
+[[package]]
+description = "Flexible and efficient upload handling for Flask"
+conda-forge = "flask-uploads"
+pypi = "Flask-Uploads"
+
+
+[[package]]
+description = "Customizable User Account Management for Flask: Register, Confirm email, Login, Change username, Change password, Forgot password and more."
+conda-forge = "flask-user"
+pypi = "Flask-User"
+
+
+[[package]]
+description = "A Flask extension to manage assets with Webpack"
+conda-forge = "flask-webpack"
+pypi = "Flask-Webpack"
+
+
+[[package]]
+description = "Simple integration of Flask and WTForms"
+conda-forge = "flask-wtf"
+pypi = "Flask-WTF"
+
+
+[[package]]
+description = "Pandas ExtensionDType/Array backed by Apache Arrow"
+conda-forge = "fletcher"
+pypi = "fletcher"
+
+
+[[package]]
+description = "Swagger Schema validation."
+conda-forge = "flex-swagger"
+pypi = "flex"
+
+
+[[package]]
+description = "Python UI tookit based on web technology"
+conda-forge = "flexx"
+pypi = "11900c3972ca2871772ca5d16d9f631a1c2dac53bd75e38bd8253f8fcd2b"
+
+
+[[package]]
+description = "Simplified packaging of Python modules"
+conda-forge = "flit"
+pypi = "flit"
+
+
+[[package]]
+description = "Celery Flower"
+conda-forge = "flower"
+pypi = "flower"
+
+
+[[package]]
+description = "Interactive dashboard for exploring influenza incidence data"
+conda-forge = "fludashboard"
+pypi = "fludashboard"
+
+
+[[package]]
+description = "Random assortment of WSGI servers"
+conda-forge = "flup"
+pypi = "flup"
+
+
+[[package]]
+description = "Make beautiful maps with Leaflet.js and Python"
+conda-forge = "folium"
+pypi = "folium"
+
+
+[[package]]
+description = "calculate confidence intervals for scikit-learn random forest regression or classification objects"
+conda-forge = "forestci"
+pypi = "forestci"
+
+
+[[package]]
+description = "HTML form validation, generation, and conversion package"
+conda-forge = "formencode"
+pypi = "FormEncode"
+
+
+[[package]]
+description = "Mimics Fortran textual IO in Python"
+conda-forge = "fortranformat"
+pypi = "fortranformat"
+
+
+[[package]]
+description = "IPython extension that help to use Fortran in the interactive session"
+conda-forge = "fortran-magic"
+pypi = "fortran-magic"
+
+
+[[package]]
+description = "A collection of useful non-standard Python functions which aim to be simple to use, highly readable but not efficient"
+conda-forge = "fpyutils"
+pypi = "fpyutils"
+
+
+[[package]]
+description = "E-Discovery and Information Retrieval Engine"
+conda-forge = "freediscovery"
+pypi = "freediscovery"
+
+
+[[package]]
+description = "Let your Python tests travel through time."
+conda-forge = "freezegun"
+pypi = "freezegun"
+
+
+[[package]]
+description = "A passive Python syntax checker"
+conda-forge = "frosted"
+pypi = "frosted"
+
+
+[[package]]
+description = "An immutable dictionary"
+conda-forge = "frozendict"
+pypi = "frozendict"
+
+
+[[package]]
+description = "Freezes a Flask application into a set of static files."
+conda-forge = "frozen-flask"
+pypi = "Frozen-Flask"
+
+
+[[package]]
+description = "A collection of wxPython widgets used by FSLeyes"
+conda-forge = "fsleyes-widgets"
+pypi = "fsleyes-widgets"
+
+
+[[package]]
+description = "Filesystem abstraction layer for Python"
+conda-forge = "fs"
+pypi = "fs"
+
+
+[[package]]
+description = "Amazon S3 filesystem for PyFilesystem2"
+conda-forge = "fs-s3fs"
+pypi = "fs-s3fs"
+
+
+[[package]]
+description = "Pyfilesystem2 over SSH using paramiko"
+conda-forge = "fs.sshfs"
+pypi = "fs.sshfs"
+
+
+[[package]]
+description = "fs.webdavfs is a WebDAV driver for PyFileSystem2."
+conda-forge = "fs.webdavfs"
+pypi = "4eb38309d71218e0ca4364db52240695497f488fee60563e37f46a8736d8"
+
+
+[[package]]
+description = "Fixes some problems with Unicode text after the fact"
+conda-forge = "ftfy"
+pypi = "ftfy"
+
+
+[[package]]
+description = "High-level FTP client library (virtual file system and more)"
+conda-forge = "ftputil"
+pypi = "ftputil"
+
+
+[[package]]
+description = "Create an argparse.ArgumentParser from function docstrings"
+conda-forge = "funcargparse"
+pypi = "funcargparse"
+
+
+[[package]]
+description = "Python function signatures from PEP362 for Python 2.6, 2.7 and 3.2+."
+conda-forge = "funcsigs"
+pypi = "funcsigs"
+
+
+[[package]]
+description = "A collection of fancy functional tools focused on practicality."
+conda-forge = "funcy"
+pypi = "funcy"
+
+
+[[package]]
+description = "URL manipulation made simple."
+conda-forge = "furl"
+pypi = "furl"
+
+
+[[package]]
+description = "Simple ctypes bindings for FUSE"
+conda-forge = "fusepy"
+pypi = "fusepy"
+
+
+[[package]]
+description = "Clean single-source support for Python 3 and 2"
+conda-forge = "future"
+pypi = "future"
+
+
+[[package]]
+description = "Fuzzy string matching in python"
+conda-forge = "fuzzywuzzy"
+pypi = "fuzzywuzzy"
+
+
+[[package]]
+description = "Automatic segmentation of electron microscopy volumes"
+conda-forge = "gala"
+pypi = "gala"
+
+
+[[package]]
+description = "Galactic Dynamics in python"
+conda-forge = "galpy"
+pypi = "galpy"
+
+
+[[package]]
+description = "A Python package for gamma-ray astronomy"
+conda-forge = "gammapy"
+pypi = "gammapy"
+
+
+[[package]]
+description = "A generic AST to represent Python2 and Python3's Abstract Syntax Tree(AST)."
+conda-forge = "gast"
+pypi = "gast"
+
+
+[[package]]
+description = "A collection of functions to use with GDAL."
+conda-forge = "gazar"
+pypi = "gazar"
+
+
+[[package]]
+description = "Pythonic file-system interface for Google Cloud Storage"
+conda-forge = "gcsfs"
+pypi = "gcsfs"
+
+
+[[package]]
+description = "Python API for the Genesis platform."
+conda-forge = "genesis-pyapi"
+pypi = "Genesis-PyAPI"
+
+
+[[package]]
+description = "AST-based Python source generation"
+conda-forge = "genpy"
+pypi = "genpy"
+
+
+[[package]]
+description = "A toolkit for generation of output for the web"
+conda-forge = "genshi"
+pypi = "Genshi"
+
+
+[[package]]
+description = "Topic Modelling for Humans"
+conda-forge = "gensim"
+pypi = "gensim"
+
+
+[[package]]
+description = "GenSON is a powerful, user-friendly JSON Schema generator."
+conda-forge = "genson"
+pypi = "genson"
+
+
+[[package]]
+description = "Using SQLAlchemy with Spatial Databases"
+conda-forge = "geoalchemy2"
+pypi = "GeoAlchemy2"
+
+
+[[package]]
+description = "Geocoder is a simple and consistent geocoding library."
+conda-forge = "geocoder"
+pypi = "geocoder"
+
+
+[[package]]
+description = "The geodesic routines from GeographicLib"
+conda-forge = "geographiclib"
+pypi = "geographiclib"
+
+
+[[package]]
+description = "Decoding and encoding Geohashes to and from latitude and longitude coordinates supporting python 3"
+conda-forge = "geohash2"
+pypi = "geohash2"
+
+
+[[package]]
+description = "geojsonio CLI - Python."
+conda-forge = "geojsonio"
+pypi = "geojsonio"
+
+
+[[package]]
+description = "Python bindings and utilities for GeoJSON"
+conda-forge = "geojson"
+pypi = "geojson"
+
+
+[[package]]
+description = "High-level geospatial plotting for Python."
+conda-forge = "geoplot"
+pypi = "geoplot"
+
+
+[[package]]
+description = "easy processing and analysis of geographic and projected rasters"
+conda-forge = "georaster"
+pypi = "georaster"
+
+
+[[package]]
+description = "Tools for working with Geographical Information System Rasters"
+conda-forge = "georasters"
+pypi = "georasters"
+
+
+[[package]]
+description = "GeoViews is a Python library that makes it easy to explore and visualize geographical, meteorological, and oceanographic datasets, such as those used in weather, climate, and remote sensing research."
+conda-forge = "geoviews-core"
+pypi = "geoviews"
+
+
+[[package]]
+description = "Coroutine-based network library"
+conda-forge = "gevent"
+pypi = "gevent"
+
+
+[[package]]
+description = "ggplot for python"
+conda-forge = "ggplot"
+pypi = "ggplot"
+
+
+[[package]]
+description = "Gherkin parser/compiler for Python"
+conda-forge = "gherkin-official"
+pypi = "gherkin-official"
+
+
+[[package]]
+description = "Webkit based webclient."
+conda-forge = "ghost.py"
+pypi = "Ghost.py"
+
+
+[[package]]
+description = "Copy your docs directly to the gh-pages branch."
+conda-forge = "ghp-import"
+pypi = "ghp-import"
+
+
+[[package]]
+description = "An astronomical image viewer and toolkit"
+conda-forge = "ginga"
+pypi = "ginga"
+
+
+[[package]]
+description = "Python client for interacting with Girder servers"
+conda-forge = "girder-client"
+pypi = "girder-client"
+
+
+[[package]]
+description = "Web-based data management platform"
+conda-forge = "girder"
+pypi = "girder"
+
+
+[[package]]
+description = "A pure-Python git object database"
+conda-forge = "gitdb2"
+pypi = "gitdb2"
+
+
+[[package]]
+description = "Git Object Database"
+conda-forge = "gitdb"
+pypi = "gitdb"
+
+
+[[package]]
+description = "Python wrapper for the GitHub API (http://developer.github.com/v3)."
+conda-forge = "github3.py"
+pypi = "github3.py"
+
+
+[[package]]
+description = "Render GeoJSON as ASCII on the commandline."
+conda-forge = "gj2ascii"
+pypi = "gj2ascii"
+
+
+[[package]]
+description = "A cross-platform curses-based monitoring tool"
+conda-forge = "glances"
+pypi = "Glances"
+
+
+[[package]]
+description = "Fast inference for Generalized Linear Mixed Models"
+conda-forge = "glimix-core"
+pypi = "glimix-core"
+
+
+[[package]]
+description = "Python wrapper for glmnet"
+conda-forge = "glmnet"
+pypi = "glmnet"
+
+
+[[package]]
+description = "Version of the glob module that supports recursion via **, and can capture patterns."
+conda-forge = "glob2"
+pypi = "glob2"
+
+
+[[package]]
+description = "Multi-dimensional linked data exploration"
+conda-forge = "glue-core"
+pypi = "glue-core"
+
+
+[[package]]
+description = "Geospatial plugin for glue"
+conda-forge = "glue-geospatial"
+pypi = "glue-geospatial"
+
+
+[[package]]
+description = "3D viewers for Glue"
+conda-forge = "glue-vispy-viewers"
+pypi = "glue-vispy-viewers"
+
+
+[[package]]
+description = "Multi-dimensional linked data exploration"
+conda-forge = "glueviz"
+pypi = "glueviz"
+
+
+[[package]]
+description = "Tools for accessing JPEG2000 files"
+conda-forge = "glymur"
+pypi = "Glymur"
+
+
+[[package]]
+description = "Google maps for Jupyter notebooks"
+conda-forge = "gmaps"
+pypi = "gmaps"
+
+
+[[package]]
+description = "GMP/MPIR, MPFR, and MPC interface to Python 2.6+ and 3.x"
+conda-forge = "gmpy2"
+pypi = "gmpy2"
+
+
+[[package]]
+description = "A Python wrapper for GnuPG"
+conda-forge = "gnupg-py"
+pypi = "gnupg"
+
+
+[[package]]
+description = "Goodness of fit tests for general datatypes"
+conda-forge = "goftests"
+pypi = "goftests"
+
+
+[[package]]
+description = "Core Library for Google Client Libraries"
+conda-forge = "google-api-core"
+pypi = "google-api-core"
+
+
+[[package]]
+description = "Google API Client Library for Python"
+conda-forge = "google-api-python-client"
+pypi = "google-api-python-client"
+
+
+[[package]]
+description = "Common protobufs used in Google APIs"
+conda-forge = "googleapis-common-protos"
+pypi = "googleapis-common-protos"
+
+
+[[package]]
+description = "Google Authentication Library httplib2 transport"
+conda-forge = "google-auth-httplib2"
+pypi = "google-auth-httplib2"
+
+
+[[package]]
+description = "Google Authentication Library, oauthlib integration with google-auth"
+conda-forge = "google-auth-oauthlib"
+pypi = "google-auth-oauthlib"
+
+
+[[package]]
+description = "Google authentication library for Python"
+conda-forge = "google-auth"
+pypi = "google-auth"
+
+
+[[package]]
+description = "Python Client for Google BigQuery"
+conda-forge = "google-cloud-bigquery"
+pypi = "google-cloud-bigquery"
+
+
+[[package]]
+description = "API Client library for Google Cloud: Core Helpers"
+conda-forge = "google-cloud-core"
+pypi = "google-cloud-core"
+
+
+[[package]]
+description = "Python Client for Google Stackdriver Monitoring"
+conda-forge = "google-cloud-monitoring"
+pypi = "google-cloud-monitoring"
+
+
+[[package]]
+description = "Python Client for Google Cloud Storage"
+conda-forge = "google-cloud-storage"
+pypi = "google-cloud-storage"
+
+
+[[package]]
+description = "Python Client for Google Maps Services"
+conda-forge = "googlemaps"
+pypi = "googlemaps"
+
+
+[[package]]
+description = "Utilities for Google Media Downloads and Resumable Uploads"
+conda-forge = "google-resumable-media"
+pypi = "google-resumable-media"
+
+
+[[package]]
+description = "Gaussian process regression with derivative constraints and predictions."
+conda-forge = "gptools"
+pypi = "gptools"
+
+
+[[package]]
+description = "GPX file parser and GPS track manipulation library."
+conda-forge = "gpxpy"
+pypi = "gpxpy"
+
+
+[[package]]
+description = "The Gaussian Process Toolbox"
+conda-forge = "gpy"
+pypi = "GPy"
+
+
+[[package]]
+description = "GraphQL client for Python"
+conda-forge = "gql"
+pypi = "gql"
+
+
+[[package]]
+description = "GraphQL Framework for Python"
+conda-forge = "graphene"
+pypi = "graphene"
+
+
+[[package]]
+description = "GraphQL implementation for Python"
+conda-forge = "graphql-core"
+pypi = "graphql-core"
+
+
+[[package]]
+description = "Relay implementation for Python"
+conda-forge = "graphql-relay"
+pypi = "graphql-relay"
+
+
+[[package]]
+description = "Always know what to expect from your data."
+conda-forge = "great-expectations"
+pypi = "great-expectations"
+
+
+[[package]]
+description = "Lightweight in-process concurrent programming"
+conda-forge = "greenlet"
+pypi = "greenlet"
+
+
+[[package]]
+description = "Green is a clean, colorful, fast python test runner"
+conda-forge = "green"
+pypi = "green"
+
+
+[[package]]
+description = "Requests + Gevent"
+conda-forge = "grequests"
+pypi = "grequests"
+
+
+[[package]]
+description = "Reading and writing of data on regular grids in Python"
+conda-forge = "griddataformats"
+pypi = "GridDataFormats"
+
+
+[[package]]
+description = "Quick grid visualization and conversion to GIS formats."
+conda-forge = "gridgeo"
+pypi = "gridgeo"
+
+
+[[package]]
+description = "Preview GitHub Markdown files like Readme locally before committing them."
+conda-forge = "grip"
+pypi = "grip"
+
+
+[[package]]
+description = "A collection of quantum algorithms built using pyQuil and Forest"
+conda-forge = "grove"
+pypi = "quantum-grove"
+
+
+[[package]]
+description = "Google Spreadsheets Python API"
+conda-forge = "gspread"
+pypi = "gspread"
+
+
+[[package]]
+description = "Object Relational Model for GSSHA model files and a toolkit to convert gridded input into GSSHA input."
+conda-forge = "gsshapy"
+pypi = "gsshapy"
+
+
+[[package]]
+description = "Gibbs SeaWater Oceanographic Package of TEOS-10"
+conda-forge = "gsw"
+pypi = "gsw"
+
+
+[[package]]
+description = "WSGI HTTP Server for UNIX"
+conda-forge = "gunicorn"
+pypi = "gunicorn"
+
+
+[[package]]
+description = "Generalized World Coordinate System"
+conda-forge = "gwcs"
+pypi = "gwcs"
+
+
+[[package]]
+description = "HTTP/2 State-Machine based protocol implementation"
+conda-forge = "h2"
+pypi = "h2"
+
+
+[[package]]
+description = "Python Objects Onto HDF5"
+conda-forge = "h5io"
+pypi = "h5io"
+
+
+[[package]]
+description = "netCDF4 via h5py."
+conda-forge = "h5netcdf"
+pypi = "h5netcdf"
+
+
+[[package]]
+description = "Wrapper for h5py with pickle capabilities"
+conda-forge = "h5pickle"
+pypi = "h5pickle"
+
+
+[[package]]
+description = "Package for studying large scale structure, cosmology, and galaxy evolution using N-body simulations and halo models."
+conda-forge = "halotools"
+pypi = "halotools"
+
+
+[[package]]
+description = "A developer-friendly Python library to interact with Apache HBase"
+conda-forge = "happybase"
+pypi = "happybase"
+
+
+[[package]]
+description = "Calculate the distance between 2 points on Earth"
+conda-forge = "haversine"
+pypi = "haversine"
+
+
+[[package]]
+description = "Clustering based on density with variable density clusters"
+conda-forge = "hdbscan"
+pypi = "hdbscan"
+
+
+[[package]]
+description = "Utilities to read/write Python types to/from HDF5 files, including MATLAB v7.3 MAT files."
+conda-forge = "hdf5storage"
+pypi = "hdf5storage"
+
+
+[[package]]
+description = "Python wrapper for libhdfs3"
+conda-forge = "hdfs3"
+pypi = "hdfs3"
+
+
+[[package]]
+description = "Project with useful classes/methods for all projects created by the HDInsight team at Microsoft around Jupyter"
+conda-forge = "hdijupyterutils"
+pypi = "hdijupyterutils"
+
+
+[[package]]
+description = "Healpix tools package for Python"
+conda-forge = "healpy"
+pypi = "healpy"
+
+
+[[package]]
+description = "Python for space physics"
+conda-forge = "heliopy"
+pypi = "HelioPy"
+
+
+[[package]]
+description = "development library for quickly writing configurable applications and daemons"
+conda-forge = "helper"
+pypi = "helper"
+
+
+[[package]]
+description = "High-ENergy Data Reduction Interface from the Command Shell"
+conda-forge = "hendrics"
+pypi = "hendrics"
+
+
+[[package]]
+description = "Code, prompt and output hiding for Jupyter/IPython notebooks."
+conda-forge = "hide_code"
+pypi = "hide_code"
+
+
+[[package]]
+description = "Python astronomy package for HiPS"
+conda-forge = "hips"
+pypi = "hips"
+
+
+[[package]]
+description = "Python wrapper for hiredis"
+conda-forge = "hiredis"
+pypi = "hiredis"
+
+
+[[package]]
+description = "Hive plots in Python!"
+conda-forge = "hiveplot"
+pypi = "hiveplot"
+
+
+[[package]]
+description = "Hive Python Thrift Libs"
+conda-forge = "hive-thrift-py"
+pypi = "hive-thrift-py"
+
+
+[[package]]
+description = "This module implements the HMAC Key Derivation function, defined at http://tools.ietf.org/html/draft-krawczyk-hkdf-01 "
+conda-forge = "hkdf"
+pypi = "hkdf"
+
+
+[[package]]
+description = "A high-level plotting API for the PyData ecosystem built on HoloViews."
+conda-forge = "holoplot"
+pypi = "holoplot"
+
+
+[[package]]
+description = "Stop plotting your data - annotate your data and let it visualize itself."
+conda-forge = "holoviews"
+pypi = "holoviews"
+
+
+[[package]]
+description = "Python downloader with progress"
+conda-forge = "homura"
+pypi = "homura"
+
+
+[[package]]
+description = "a module to find a maximum matching in bipartite graphs"
+conda-forge = "hopcroftkarp"
+pypi = "hopcroftkarp"
+
+
+[[package]]
+description = "HTTP/2 Header Encoding for Python"
+conda-forge = "hpack"
+pypi = "hpack"
+
+
+[[package]]
+description = "HydroShare REST API client library"
+conda-forge = "hs_restclient"
+pypi = "hs_restclient"
+
+
+[[package]]
+description = "HTML parser based on the WHATWG HTML specification"
+conda-forge = "html5lib"
+pypi = "html5lib"
+
+
+[[package]]
+description = "A configurable HTML Minifier with safety features"
+conda-forge = "htmlmin"
+pypi = "htmlmin"
+
+
+[[package]]
+description = "Extracts OS Browser etc information from http user agent string"
+conda-forge = "httpagentparser"
+pypi = "httpagentparser"
+
+
+[[package]]
+description = "a CLI, cURL-like tool for humans"
+conda-forge = "httpie"
+pypi = "httpie"
+
+
+[[package]]
+description = "A comprehensive HTTP client library"
+conda-forge = "httplib2"
+pypi = "httplib2"
+
+
+[[package]]
+description = "HTTP client mock for Python."
+conda-forge = "httpretty"
+pypi = "httpretty"
+
+
+[[package]]
+description = "Fast HTTP parser"
+conda-forge = "httptools"
+pypi = "httptools"
+
+
+[[package]]
+description = "A Python framework that makes developing APIs as simple as possible,\nbut no simpler.\n"
+conda-forge = "hug"
+pypi = "hug"
+
+
+[[package]]
+description = "Human friendly output for text interfaces using Python."
+conda-forge = "humanfriendly"
+pypi = "humanfriendly"
+
+
+[[package]]
+description = "Pure-Python HTTP/2 framing "
+conda-forge = "hyperframe"
+pypi = "hyperframe"
+
+
+[[package]]
+description = "Hyperion Radiation Transfer Code"
+conda-forge = "hyperion-fortran"
+pypi = "hyperion"
+
+
+[[package]]
+description = "Hyperion Radiation Transfer Code"
+conda-forge = "hyperion"
+pypi = "hyperion"
+
+
+[[package]]
+description = "Immutable, Pythonic, correct URLs."
+conda-forge = "hyperlink"
+pypi = "hyperlink"
+
+
+[[package]]
+description = "HTTP/2 for Python."
+conda-forge = "hyper"
+pypi = "hyper"
+
+
+[[package]]
+description = "ipywidgets GUI elements for HyperSpy."
+conda-forge = "hyperspy-gui-ipywidgets"
+pypi = "hyperspy-gui-ipywidgets"
+
+
+[[package]]
+description = "traitsui GUI elements for HyperSpy."
+conda-forge = "hyperspy-gui-traitsui"
+pypi = "hyperspy-gui-traitsui"
+
+
+[[package]]
+description = "Multi-dimensional data analysis"
+conda-forge = "hyperspy"
+pypi = "hyperspy"
+
+
+[[package]]
+description = "HTTP/2 for Python."
+conda-forge = "hypertemp"
+pypi = "hypertemp"
+
+
+[[package]]
+description = "A library for property based testing"
+conda-forge = "hypothesis"
+pypi = "hypothesis"
+
+
+[[package]]
+description = "Lisp and Python love each other."
+conda-forge = "hy"
+pypi = "hy"
+
+
+[[package]]
+description = "Python implementation of standards from The InternationalAssociation for the Properties of Water and Steam"
+conda-forge = "iapws"
+pypi = "iapws"
+
+
+[[package]]
+description = "iCalendar parser/generator"
+conda-forge = "icalendar"
+pypi = "icalendar"
+
+
+[[package]]
+description = "Internationalized Domain Names in Applications (IDNA)."
+conda-forge = "idna"
+pypi = "idna"
+
+
+[[package]]
+description = "Patch ssl.match_hostname for Unicode(idna) domains support"
+conda-forge = "idna_ssl"
+pypi = "idna_ssl"
+
+
+[[package]]
+description = "Python parsers for WaveMetrics Igor Binary Waves and Packed Experiment files"
+conda-forge = "igor"
+pypi = "igor"
+
+
+[[package]]
+description = "Reads ImageJ ROIs."
+conda-forge = "ijroi"
+pypi = "ijroi"
+
+
+[[package]]
+description = "Ijson is an iterative JSON parser with a standard Python iterator interface."
+conda-forge = "ijson"
+pypi = "ijson"
+
+
+[[package]]
+description = "A Python Perceptual Image Hahsing Module"
+conda-forge = "imagehash"
+pypi = "ImageHash"
+
+
+[[package]]
+description = "a Python library for reading and writing image data"
+conda-forge = "imageio"
+pypi = "imageio"
+
+
+[[package]]
+description = "interactive python image-processing plugin framework"
+conda-forge = "imagepy"
+pypi = "imagepy"
+
+
+[[package]]
+description = "Getting image size from png/jpeg/jpeg2000/gif file"
+conda-forge = "imagesize"
+pypi = "imagesize"
+
+
+[[package]]
+description = "a tool to simulate neutron resonance signal for neutron resonance imaging"
+conda-forge = "imagingreso"
+pypi = "ImagingReso"
+
+
+[[package]]
+description = "Easy-to-use, Pythonic and complete IMAP client library"
+conda-forge = "imapclient"
+pypi = "IMAPClient"
+
+
+[[package]]
+description = "Python module to balance data set using under- and over-sampling"
+conda-forge = "imbalanced-learn"
+pypi = "imbalanced-learn"
+
+
+[[package]]
+description = "A package to help perform command-line image examination and plotting"
+conda-forge = "imexam"
+pypi = "imexam"
+
+
+[[package]]
+description = "Python utility functions for slices."
+conda-forge = "imgroi"
+pypi = "imgroi"
+
+
+[[package]]
+description = "Official Imgur python library with OAuth2 and samples"
+conda-forge = "imgurpython"
+pypi = "imgurpython"
+
+
+[[package]]
+description = "Interactive Minimization Tools based on MINUIT"
+conda-forge = "iminuit"
+pypi = "iminuit"
+
+
+[[package]]
+description = "Immutable Collections"
+conda-forge = "immutables"
+pypi = "immutables"
+
+
+[[package]]
+description = "Fast Python Collaborative Filtering for Implicit Datasets."
+conda-forge = "implicit"
+pypi = "implicit"
+
+
+[[package]]
+description = "Backport of Python 3.7's standard library `importlib.resources`."
+conda-forge = "importlib_resources"
+pypi = "importlib_resources"
+
+
+[[package]]
+description = "Import .ipynb files as modules in the system path"
+conda-forge = "importnb"
+pypi = "importnb"
+
+
+[[package]]
+description = "Recursively import modules and sub-packages"
+conda-forge = "importscan"
+pypi = "importscan"
+
+
+[[package]]
+description = "Python client for the Impala distributed query engine"
+conda-forge = "impyla"
+pypi = "impyla"
+
+
+[[package]]
+description = "Incremental is a small library that versions your Python projects."
+conda-forge = "incremental"
+pypi = "incremental"
+
+
+[[package]]
+description = "Fast random access of gzip files in Python"
+conda-forge = "indexed_gzip"
+pypi = "indexed_gzip"
+
+
+[[package]]
+description = "All-in-one infinity value for Python. Can be compared to any object."
+conda-forge = "infinity"
+pypi = "infinity"
+
+
+[[package]]
+description = "A port of Ruby on Rails inflector to Python"
+conda-forge = "inflection"
+pypi = "inflection"
+
+
+[[package]]
+description = "Correctly generate plurals, singular nouns, ordinals, indefinite articles; convert numbers to words"
+conda-forge = "inflect"
+pypi = "inflect"
+
+
+[[package]]
+description = "A small INI library for Python."
+conda-forge = "inifile"
+pypi = "inifile"
+
+
+[[package]]
+description = "Python script for inlining CSS stylesheets and conversion of resources to data-uri.\n"
+conda-forge = "inline-html"
+pypi = "inline-html"
+
+
+[[package]]
+description = "A framework for creating bio-inspired computational intelligence algorithms"
+conda-forge = "inspyred"
+pypi = "inspyred"
+
+
+[[package]]
+description = "Instant Global Broadband Seismograms Based on a Waveform Database"
+conda-forge = "instaseis"
+pypi = "instaseis"
+
+
+[[package]]
+description = "Python library for Intel HEX files manipulations"
+conda-forge = "intelhex"
+pypi = "intelhex"
+
+
+[[package]]
+description = "interlap: fast, simple interval overlap testing"
+conda-forge = "interlap"
+pypi = "interlap"
+
+
+[[package]]
+description = "Python tools for handling intervals (ranges of comparable objects)."
+conda-forge = "intervals"
+pypi = "intervals"
+
+
+[[package]]
+description = "Editable interval tree data structure for Python 2 and 3"
+conda-forge = "intervaltree"
+pypi = "intervaltree"
+
+
+[[package]]
+description = "Pythonic task execution"
+conda-forge = "invoke"
+pypi = "invoke"
+
+
+[[package]]
+description = "Collection of utilities, scripts and tests to assist in automated quality assurance."
+conda-forge = "ioos_qartod"
+pypi = "ioos_qartod"
+
+
+[[package]]
+description = "Misc functions for IOOS notebooks"
+conda-forge = "ioos_tools"
+pypi = "ioos_tools"
+
+
+[[package]]
+description = "Platform-independent module for I/O completion events"
+conda-forge = "iowait"
+pypi = "iowait"
+
+
+[[package]]
+description = "IPv4/IPv6 manipulation library"
+conda-forge = "ipaddress"
+pypi = "ipaddress"
+
+
+[[package]]
+description = "Google's Python IP address manipulation library"
+conda-forge = "ipaddr"
+pypi = "ipaddr"
+
+
+[[package]]
+description = "Defines a %%cache cell magic in the IPython notebook to cache results of long-lasting computations in a persistentpickle file."
+conda-forge = "ipycache"
+pypi = "ipycache"
+
+
+[[package]]
+description = "A set of widgets to help facilitate reuse of large datasets across widgets"
+conda-forge = "ipydatawidgets"
+pypi = "ipydatawidgets"
+
+
+[[package]]
+description = "A custom widget for returning mouse and keyboard events to Python"
+conda-forge = "ipyevents"
+pypi = "ipyevents"
+
+
+[[package]]
+description = "IPython Kernel for Jupyter"
+conda-forge = "ipykernel"
+pypi = "ipykernel"
+
+
+[[package]]
+description = "A Jupyter widget for dynamic Leaflet maps"
+conda-forge = "ipyleaflet"
+pypi = "ipyleaflet"
+
+
+[[package]]
+description = "Matplotlib Jupyter Extension"
+conda-forge = "ipympl"
+pypi = "ipympl"
+
+
+[[package]]
+description = "Interactive Parallel Computing with IPython"
+conda-forge = "ipyparallel"
+pypi = "ipyparallel"
+
+
+[[package]]
+description = "A jupyter widget (or ipywidget) wrapping the very convenient pivotTable.js library"
+conda-forge = "ipypivot"
+pypi = "ipypivot"
+
+
+[[package]]
+description = "A widget library for scales"
+conda-forge = "ipyscales"
+pypi = "ipyscales"
+
+
+[[package]]
+description = "Time everything in IPython"
+conda-forge = "ipython-autotime"
+pypi = "ipython-autotime"
+
+
+[[package]]
+description = "Vestigial utilities from IPython"
+conda-forge = "ipython_genutils"
+pypi = "ipython_genutils"
+
+
+[[package]]
+description = "IPython: Productive Interactive Computing"
+conda-forge = "ipython"
+pypi = "ipython"
+
+
+[[package]]
+description = "RDBMS access via IPython"
+conda-forge = "ipython-sql"
+pypi = "ipython-sql"
+
+
+[[package]]
+description = "Add unittest cell magics to IPython for easily running tests"
+conda-forge = "ipython_unittest"
+pypi = "ipython_unittest"
+
+
+[[package]]
+description = "IPython widget for rendering 3d volumes in the Jupter notebook"
+conda-forge = "ipyvolume"
+pypi = "ipyvolume"
+
+
+[[package]]
+description = "WebRTC for Jupyter notebook/lab"
+conda-forge = "ipywebrtc"
+pypi = "ipywebrtc"
+
+
+[[package]]
+description = "A jupyter widget (or ipywidget) wrapping the very convenient pivotTable.js library"
+conda-forge = "ipypivot"
+pypi = "ipypivot"
+
+
+[[package]]
+description = "Jupyter Interactive Widgets"
+conda-forge = "ipywidgets"
+pypi = "ipywidgets"
+
+
+[[package]]
+description = "Wrapper around isl, an integer set library"
+conda-forge = "islpy"
+pypi = "islpy"
+
+
+[[package]]
+description = "Simple module to parse ISO 8601 dates"
+conda-forge = "iso8601"
+pypi = "iso8601"
+
+
+[[package]]
+description = "An ISO 8601 date/time/duration parser and formatter."
+conda-forge = "isodate"
+pypi = "isodate"
+
+
+[[package]]
+description = "A Python utility / library to sort Python imports."
+conda-forge = "isort"
+pypi = "isort"
+
+
+[[package]]
+description = "Utilities based on Pythons iterators and generators."
+conda-forge = "iteration_utilities"
+pypi = "iteration_utilities"
+
+
+[[package]]
+description = "Various helpers to pass trusted data to untrusted environments."
+conda-forge = "itsdangerous"
+pypi = "itsdangerous"
+
+
+[[package]]
+description = "Basic immutable container types for Python."
+conda-forge = "itypes"
+pypi = "itypes"
+
+
+[[package]]
+description = "jaraco.classes"
+conda-forge = "jaraco.classes"
+pypi = "jaraco.classes"
+
+
+[[package]]
+description = "jaraco.logging"
+conda-forge = "jaraco.logging"
+pypi = "jaraco.logging"
+
+
+[[package]]
+description = "Routines for dealing with data streams"
+conda-forge = "jaraco.stream"
+pypi = "jaraco.stream"
+
+
+[[package]]
+description = "A Python DB-APIv2.0 compliant library for JDBC Drivers"
+conda-forge = "jaydebeapi"
+pypi = "JayDeBeApi"
+
+
+[[package]]
+description = "a C++ code generator for calling Java from C++/Python"
+conda-forge = "jcc"
+pypi = "de30ac0a450a66be9c679a80a05b943b40c27ea962d79770698cf1c737b7"
+
+
+[[package]]
+description = "Jalali datetime binding for python"
+conda-forge = "jdatetime"
+pypi = "jdatetime"
+
+
+[[package]]
+description = "Julian dates from proleptic Gregorian and Julian calendars."
+conda-forge = "jdcal"
+pypi = "jdcal"
+
+
+[[package]]
+description = "An autocompletion tool for Python that can be used for text editors."
+conda-forge = "jedi"
+pypi = "jedi"
+
+
+[[package]]
+description = "Pure Python DBus interface"
+conda-forge = "jeepney"
+pypi = "jeepney"
+
+
+[[package]]
+description = "a library for doing approximate and phonetic matching of strings."
+conda-forge = "jellyfish"
+pypi = "jellyfish"
+
+
+[[package]]
+description = "Compute Natural Breaks (Jenks algorythm)"
+conda-forge = "jenkspy"
+pypi = "jenkspy"
+
+
+[[package]]
+description = "Collection of small useful helper tools for Python by Johannes Feist"
+conda-forge = "jftools"
+pypi = "jftools"
+
+
+[[package]]
+description = "Chinese Words Segementation Utilities"
+conda-forge = "jieba3k"
+pypi = "jieba3k"
+
+
+[[package]]
+description = "Chinese Words Segementation Utilities"
+conda-forge = "jieba"
+pypi = "jieba"
+
+
+[[package]]
+description = "An easy to use stand-alone template engine written in pure python."
+conda-forge = "jinja2"
+pypi = "Jinja2"
+
+
+[[package]]
+description = "The easiest way to automate JIRA"
+conda-forge = "jira"
+pypi = "jira"
+
+
+[[package]]
+description = "JSON Matching Expressions"
+conda-forge = "jmespath"
+pypi = "jmespath"
+
+
+[[package]]
+description = "A Python interface to the OOMMF micromagnetic calculator"
+conda-forge = "joommf"
+pypi = "joommf"
+
+
+[[package]]
+description = "Utilities for JOOMMF"
+conda-forge = "joommfutil"
+pypi = "joommfutil"
+
+
+[[package]]
+description = "Python version of NASA DE4xx ephemerides, the basis for the Astronomical Alamanac"
+conda-forge = "jplephem"
+pypi = "jplephem"
+
+
+[[package]]
+description = "JavaScript minifier"
+conda-forge = "jsmin"
+pypi = "jsmin"
+
+
+[[package]]
+description = "Python client implementation for JSON API 1.0"
+conda-forge = "jsonapi-requests"
+pypi = "jsonapi-requests"
+
+
+[[package]]
+description = "JSON with datetime support"
+conda-forge = "jsondate"
+pypi = "jsondate"
+
+
+[[package]]
+description = "A reusable Django field that allows you to store validated JSON in your model."
+conda-forge = "jsonfield"
+pypi = "jsonfield"
+
+
+[[package]]
+description = "Library with helpers for the jsonlines file format"
+conda-forge = "jsonlines"
+pypi = "jsonlines"
+
+
+[[package]]
+description = "Apply JSON-Patches (RFC 6902)"
+conda-forge = "jsonpatch"
+pypi = "jsonpatch"
+
+
+[[package]]
+description = "Python library for serializing any arbitrary object graph into JSON. It can take almost any Python object and turn the object into JSON. Additionally, it can reconstitute the object back into Python."
+conda-forge = "jsonpickle"
+pypi = "jsonpickle"
+
+
+[[package]]
+description = "Identify specific nodes in a JSON document (RFC 6901)"
+conda-forge = "jsonpointer"
+pypi = "jsonpointer"
+
+
+[[package]]
+description = "JSON-RPC transport realisation"
+conda-forge = "json-rpc"
+pypi = "json-rpc"
+
+
+[[package]]
+description = "An implementation of JSON Schema validation for Python"
+conda-forge = "jsonschema"
+pypi = "jsonschema"
+
+
+[[package]]
+description = "Generate Pandas data frames, load and extract data, based on JSON Table Schema descriptors."
+conda-forge = "jsontableschema-pandas"
+pypi = "jsontableschema-pandas"
+
+
+[[package]]
+description = "A utility library for working with JSON Table Schema in Python"
+conda-forge = "jsontableschema"
+pypi = "jsontableschema"
+
+
+[[package]]
+description = "Extra features for Python's JSON: comments, order, numpy, pandas, datetimes, and many more! Simple but customizable."
+conda-forge = "json_tricks"
+pypi = "json_tricks"
+
+
+[[package]]
+description = "Task based Python workflow system"
+conda-forge = "jug"
+pypi = "Jug"
+
+
+[[package]]
+description = "jupyter_client contains the reference implementation of the Jupyter protocol."
+conda-forge = "jupyter_client"
+pypi = "jupyter_client"
+
+
+[[package]]
+description = "Jupyter Notebook Content Management Extensions"
+conda-forge = "jupyter_cms"
+pypi = "jupyter_cms"
+
+
+[[package]]
+description = "Jupyter terminal console"
+conda-forge = "jupyter_console"
+pypi = "jupyter_console"
+
+
+[[package]]
+description = "Common utilities for jupyter-contrib projects."
+conda-forge = "jupyter_contrib_core"
+pypi = "jupyter_contrib_core"
+
+
+[[package]]
+description = "A collection of various different notebook extensions for Jupyter"
+conda-forge = "jupyter_contrib_nbextensions"
+pypi = "jupyter_contrib_nbextensions"
+
+
+[[package]]
+description = "Core common functionality of Jupyter projects."
+conda-forge = "jupyter_core"
+pypi = "jupyter_core"
+
+
+[[package]]
+description = "Jupyter Dashboards Layout Extension"
+conda-forge = "jupyter_dashboards"
+pypi = "jupyter_dashboards"
+
+
+[[package]]
+description = "Install the coding dojo extension for ipython_unittest"
+conda-forge = "jupyter_dojo"
+pypi = "jupyter_dojo"
+
+
+[[package]]
+description = "A web server for spawning and communicating with remote Jupyter kernels"
+conda-forge = "jupyter_enterprise_gateway"
+pypi = "jupyter_enterprise_gateway"
+
+
+[[package]]
+description = "Add a button to allow jupyter to use the full browser width"
+conda-forge = "jupyter_full_width"
+pypi = "jupyter_full_width"
+
+
+[[package]]
+description = "Jupyter notebook extension that enables highlighting of all instances of\nthe currently-selected or cursor-adjecent word in either the current cell's\neditor, or in the whole notebook.\nBased on the  CodeMirror addon\nhttps://codemirror.net/demo/matchhighlighter.html\nextended to work across multiple editors.\n"
+conda-forge = "jupyter_highlight_selected_word"
+pypi = "jupyter_highlight_selected_word"
+
+
+[[package]]
+description = "LDAP Authenticator for JupyterHub"
+conda-forge = "jupyterhub-ldapauthenticator"
+pypi = "jupyterhub-ldapauthenticator"
+
+
+[[package]]
+description = "Multi-user server for Jupyter notebooks"
+conda-forge = "jupyterhub"
+pypi = "jupyterhub"
+
+
+[[package]]
+description = "Jupyter Kernel Gateway"
+conda-forge = "jupyter_kernel_gateway"
+pypi = "jupyter_kernel_gateway"
+
+
+[[package]]
+description = "A Launcher for JupyterLab based applications."
+conda-forge = "jupyterlab_launcher"
+pypi = "jupyterlab_launcher"
+
+
+[[package]]
+description = "An extensible environment for interactive and reproducible computing, based on the Jupyter Notebook and Architecture. Currently in beta.\n"
+conda-forge = "jupyterlab"
+pypi = "jupyterlab"
+
+
+[[package]]
+description = "Jupyter nbextension providing some LaTeX environments for markdown cells."
+conda-forge = "jupyter_latex_envs"
+pypi = "jupyter_latex_envs"
+
+
+[[package]]
+description = "A server extension for jupyter notebook providing configuration interfaces for notebook extensions (nbextensions)."
+conda-forge = "jupyter_nbextensions_configurator"
+pypi = "jupyter_nbextensions_configurator"
+
+
+[[package]]
+description = "A Jupyter Notebook magic for browser notifications of cell completion"
+conda-forge = "jupyternotify"
+pypi = "jupyternotify"
+
+
+[[package]]
+description = "Drag and drop Pivot Tables and Charts for Jupyter/IPython Notebook, care of PivotTable.js"
+conda-forge = "jupyter_pivottablejs"
+pypi = "bd261fdff9f6a6e8e28abbb1b007b812b1feb1b6bfaf43191f042f4e1c3c"
+
+
+[[package]]
+description = "Color Schemes for Jupyter Qt Console"
+conda-forge = "jupyter_qtconsole_colorschemes"
+pypi = "jupyter_qtconsole_colorschemes"
+
+
+[[package]]
+description = "Jupyter metapackage. Install all the Jupyter components in one go."
+conda-forge = "jupyter"
+pypi = "jupyter"
+
+
+[[package]]
+description = "Jupyter Sphinx extensions enable Jupyter-specific features in Sphinx."
+conda-forge = "jupyter_sphinx"
+pypi = "jupyter_sphinx"
+
+
+[[package]]
+description = "Custom CSS themer for jupyter notebooks"
+conda-forge = "jupyter-themer"
+pypi = "jupyter-themer"
+
+
+[[package]]
+description = "Select and install a Jupyter notebook theme"
+conda-forge = "jupyterthemes"
+pypi = "jupyterthemes"
+
+
+[[package]]
+description = "Pure Python client for Apache Kafka"
+conda-forge = "kafka-python"
+pypi = "kafka-python"
+
+
+[[package]]
+description = "Astronomical package for spatial and spectral coordinates, WCS projections and transformation, and more..."
+conda-forge = "kapteyn"
+pypi = "kapteyn"
+
+
+[[package]]
+description = "Write-once-read-many key-array store"
+conda-forge = "kastore"
+pypi = "kastore"
+
+
+[[package]]
+description = "Kazoo is a high-level Python library that makes it easier to use Apache Zookeeper"
+conda-forge = "kazoo"
+pypi = "kazoo"
+
+
+[[package]]
+description = "An HTTP handler for urllib that supports HTTP 1.1 and keepalive in both Python 2.x and 3.x versions."
+conda-forge = "keepalive"
+pypi = "keepalive"
+
+
+[[package]]
+description = "Python utility functions for slices."
+conda-forge = "kenjutsu"
+pypi = "kenjutsu"
+
+
+[[package]]
+description = "Adds conda environment activation to Jupyter kernel specs"
+conda-forge = "kernda"
+pypi = "kernda"
+
+
+[[package]]
+description = "Alternate keyring backend implementations for use with the keyring package."
+conda-forge = "keyrings.alt"
+pypi = "keyrings.alt"
+
+
+[[package]]
+description = "Authentication Library for OpenStack Identity"
+conda-forge = "keystoneauth1"
+pypi = "keystoneauth1"
+
+
+[[package]]
+description = "A python remote communications library"
+conda-forge = "kiwipy"
+pypi = "kiwipy"
+
+
+[[package]]
+description = "A fast implementation of the Cassowary constraint solver"
+conda-forge = "kiwisolver"
+pypi = "kiwisolver"
+
+
+[[package]]
+description = "Python interface YARN"
+conda-forge = "knit"
+pypi = "knit"
+
+
+[[package]]
+description = "An embarrassingly parallel, kernel-density-based ensemble sampler"
+conda-forge = "kombine"
+pypi = "kombine"
+
+
+[[package]]
+description = "Messaging library for Python"
+conda-forge = "kombu"
+pypi = "kombu"
+
+
+[[package]]
+description = "Simple task queue for Python"
+conda-forge = "kuyruk"
+pypi = "Kuyruk"
+
+
+[[package]]
+description = "Language detection library ported from Google's language-detection."
+conda-forge = "langdetect"
+pypi = "langdetect"
+
+
+[[package]]
+description = "Linear Assignment Problem solver (LAPJV/LAPMOD)."
+conda-forge = "lap"
+pypi = "lap"
+
+
+[[package]]
+description = "A fast and thorough lazy object proxy."
+conda-forge = "lazy-object-proxy"
+pypi = "lazy-object-proxy"
+
+
+[[package]]
+description = "Lazy attributes for Python objects"
+conda-forge = "lazy"
+pypi = "lazy"
+
+
+[[package]]
+description = "A strictly RFC 4510 conforming LDAP V3 pure Python client library"
+conda-forge = "ldap3"
+pypi = "ldap3"
+
+
+[[package]]
+description = "LDAP utils."
+conda-forge = "ldap"
+pypi = "ldap"
+
+
+[[package]]
+description = "A Pure-Python Twisted library for LDAP"
+conda-forge = "ldaptor"
+pypi = "ldaptor"
+
+
+[[package]]
+description = "Python charting for 80% of humans."
+conda-forge = "leather"
+pypi = "leather"
+
+
+[[package]]
+description = "The lektor static file content management system."
+conda-forge = "lektor"
+pypi = "Lektor"
+
+
+[[package]]
+description = "Python LESS compiler"
+conda-forge = "lesscpy"
+pypi = "lesscpy"
+
+
+[[package]]
+description = "A Python library for working with neuronal models specified in NeuroML 2"
+conda-forge = "libneuroml"
+pypi = "libNeuroML"
+
+
+[[package]]
+description = "Python module for audio and music processing"
+conda-forge = "librosa"
+pypi = "librosa"
+
+
+[[package]]
+description = "A straightforward binding of libsass for Python. Compile Sass/SCSS in Python with no Ruby stack at all!"
+conda-forge = "libsass"
+pypi = "libsass"
+
+
+[[package]]
+description = "A Python implementation of LightFM, a hybrid recommendation algorithm."
+conda-forge = "lightfm"
+pypi = "lightfm"
+
+
+[[package]]
+description = "LightGBM is a gradient boosting framework that uses tree based learning algorithms."
+conda-forge = "lightgbm"
+pypi = "lightgbm"
+
+
+[[package]]
+description = "Representations of semi-open intervals"
+conda-forge = "ligo-segments"
+pypi = "ligo-segments"
+
+
+[[package]]
+description = "A pure-python version of lal.LIGOTimeGPS"
+conda-forge = "ligotimegps"
+pypi = "ligotimegps"
+
+
+[[package]]
+description = "Liknorm Python wrapper"
+conda-forge = "liknorm-py"
+pypi = "liknorm"
+
+
+[[package]]
+description = "Explaining the predictions of any machine learning classifier"
+conda-forge = "lime"
+pypi = "lime"
+
+
+[[package]]
+description = "Fast inference for Linear Mixed Models"
+conda-forge = "limix-core"
+pypi = "limix-core"
+
+
+[[package]]
+description = "Fast inference for Generalized Linear Mixed Models"
+conda-forge = "limix-inference"
+pypi = "limix-inference"
+
+
+[[package]]
+description = "A flexible and fast mixed model toolbox"
+conda-forge = "limix-legacy"
+pypi = "limix-legacy"
+
+
+[[package]]
+description = "A flexible and fast mixed model toolbox"
+conda-forge = "limix"
+pypi = "limix"
+
+
+[[package]]
+description = "Line-oriented, tab-separated value format"
+conda-forge = "linear-tsv"
+pypi = "linear-tsv"
+
+
+[[package]]
+description = "Backport of the linecache module"
+conda-forge = "linecache2"
+pypi = "linecache2"
+
+
+[[package]]
+description = "A module for monitoring memory usage of a python program"
+conda-forge = "line_profiler"
+pypi = "line_profiler"
+
+
+[[package]]
+description = "A fork to traitlets' link and dlink to link traits in addition to traitlets."
+conda-forge = "link-traits"
+pypi = "link-traits"
+
+
+[[package]]
+description = "A lightweight LLVM python binding for writing JIT compilers."
+conda-forge = "llvmlite"
+pypi = "llvmlite"
+
+
+[[package]]
+description = "Load me later. A lazy loading plugin management system."
+conda-forge = "lml"
+pypi = "lml"
+
+
+[[package]]
+description = "File-based locks for Python for Linux and Windows"
+conda-forge = "locket"
+pypi = "locket"
+
+
+[[package]]
+description = "Platform-independent file locking module"
+conda-forge = "lockfile"
+pypi = "lockfile"
+
+
+[[package]]
+description = "Scalable user load testing tool written in Python"
+conda-forge = "locust"
+pypi = "locust"
+
+
+[[package]]
+description = "Self-logging exceptions: Attach log messages to exceptions and output them conditionally."
+conda-forge = "logging_exceptions"
+pypi = "logging_exceptions"
+
+
+[[package]]
+description = "Generate changelogs based on Github milestones or tags."
+conda-forge = "loghub"
+pypi = "loghub"
+
+
+[[package]]
+description = "collection of low-level Python packages and modules used by Logilab projects"
+conda-forge = "logilab-common"
+pypi = "logilab-common"
+
+
+[[package]]
+description = "Python logging made easy"
+conda-forge = "logzero"
+pypi = "logzero"
+
+
+[[package]]
+description = "A robust implementation of concurrent.futures.ProcessPoolExecutor"
+conda-forge = "loky"
+pypi = "loky"
+
+
+[[package]]
+description = "Work with .loom files for single-cell RNA-seq data"
+conda-forge = "loompy"
+pypi = "loompy"
+
+
+[[package]]
+description = "Generator for random text that looks like Latin"
+conda-forge = "lorem"
+pypi = "lorem"
+
+
+[[package]]
+description = "Implementation of the Louvain algorithm for various methods for use with igraph in python."
+conda-forge = "louvain"
+pypi = "louvain"
+
+
+[[package]]
+description = "Grid LSC User Engine"
+conda-forge = "lscsoft-glue"
+pypi = "lscsoft-glue"
+
+
+[[package]]
+description = "Data analysis tools for Lumicks Bluelake"
+conda-forge = "lumicks.pylake"
+pypi = "lumicks.pylake"
+
+
+[[package]]
+description = "Pythonic binding for the C libraries libxml2 and libxslt."
+conda-forge = "lxml"
+pypi = "lxml"
+
+
+[[package]]
+description = "LZ4 Bindings for Python"
+conda-forge = "lz4"
+pypi = "lz4"
+
+
+[[package]]
+description = "lz-string for python"
+conda-forge = "lzstring"
+pypi = "lzstring"
+
+
+[[package]]
+description = "Mach-O header analysis and editing"
+conda-forge = "macholib"
+pypi = "macholib"
+
+
+[[package]]
+description = "Mahotas: Computer Vision Library"
+conda-forge = "mahotas"
+pypi = "mahotas"
+
+
+[[package]]
+description = "A super-fast templating language that borrows the best ideas from the existing templating languages."
+conda-forge = "mako"
+pypi = "Mako"
+
+
+[[package]]
+description = "\"Matteo's library and tools in Python for NuSTAR timing\""
+conda-forge = "maltpynt"
+pypi = "maltpynt"
+
+
+[[package]]
+description = "Create Python CLI apps with little to no effort at all!"
+conda-forge = "mando"
+pypi = "mando"
+
+
+[[package]]
+description = "A Python module with mapping functions for PostGIS enabled PostgreSQL databases."
+conda-forge = "mapkit"
+pypi = "mapkit"
+
+
+[[package]]
+description = "Read better test failures."
+conda-forge = "marbles-core"
+pypi = "marbles.core"
+
+
+[[package]]
+description = "Read better test failures."
+conda-forge = "marbles-mixins"
+pypi = "marbles.mixins"
+
+
+[[package]]
+description = "Read better test failures."
+conda-forge = "marbles"
+pypi = "marbles"
+
+
+[[package]]
+description = "A fast and complete Python implementation of Markdown"
+conda-forge = "markdown2"
+pypi = "markdown2"
+
+
+[[package]]
+description = "Python implementation of Markdown."
+conda-forge = "markdown"
+pypi = "Markdown"
+
+
+[[package]]
+description = "Draft.js sample content generated with Markov chains of Project Gutenberg books."
+conda-forge = "markov_draftjs"
+pypi = "markov_draftjs"
+
+
+[[package]]
+description = "A simple, extensible Markov chain generator. Uses include generating random semi-plausible sentences based on an existing text."
+conda-forge = "markovify"
+pypi = "markovify"
+
+
+[[package]]
+description = "A Python module that implements the jinja2.Markup string"
+conda-forge = "markupsafe"
+pypi = "MarkupSafe"
+
+
+[[package]]
+description = "JSON API 1.0 formatting with marshmallow"
+conda-forge = "marshmallow-jsonapi"
+pypi = "marshmallow-jsonapi"
+
+
+[[package]]
+description = "A lightweight library for converting complex datatypes to and from native Python datatypes."
+conda-forge = "marshmallow"
+pypi = "marshmallow"
+
+
+[[package]]
+description = "SQLAlchemy integration with marshmallow"
+conda-forge = "marshmallow-sqlalchemy"
+pypi = "marshmallow-sqlalchemy"
+
+
+[[package]]
+description = "Python wrapper for the Mastodon API"
+conda-forge = "mastodon.py"
+pypi = "Mastodon.py"
+
+
+[[package]]
+description = "MatchPy is a pattern matching library for Python."
+conda-forge = "matchpy"
+pypi = "matchpy"
+
+
+[[package]]
+description = "Functions for plotting area-proportional two- and three-way Venn diagrams in matplotlib."
+conda-forge = "matplotlib-venn"
+pypi = "matplotlib-venn"
+
+
+[[package]]
+description = "Datetimes for Humans"
+conda-forge = "maya"
+pypi = "maya"
+
+
+[[package]]
+description = "McCabe complexity checker for Python"
+conda-forge = "mccabe"
+pypi = "mccabe"
+
+
+[[package]]
+description = "An object-oriented toolkit to analyze molecular dynamics trajectories generated by CHARMM, Gromacs, NAMD, LAMMPS, or Amber."
+conda-forge = "mdanalysis"
+pypi = "MDAnalysis"
+
+
+[[package]]
+description = "Tests and test files for MDAnalysis package"
+conda-forge = "mdanalysistests"
+pypi = "MDAnalysisTests"
+
+
+[[package]]
+description = "Benchmark GROMACS simulations"
+conda-forge = "mdbenchmark"
+pypi = "mdbenchmark"
+
+
+[[package]]
+description = "Easy access to shared MD data."
+conda-forge = "mdshare"
+pypi = "mdshare"
+
+
+[[package]]
+description = "Simple server to visualize remote trajectories."
+conda-forge = "mdsrv"
+pypi = "MDsrv"
+
+
+[[package]]
+description = "a persistence engine for molecular dynamics data"
+conda-forge = "mdsynthesis"
+pypi = "mdsynthesis"
+
+
+[[package]]
+description = "An utility that is able to generate a table of contents for a markdown file"
+conda-forge = "md-toc"
+pypi = "md_toc"
+
+
+[[package]]
+description = "A modern, open library for the analysis of molecular dynamics trajectories"
+conda-forge = "mdtraj"
+pypi = "mdtraj"
+
+
+[[package]]
+description = "An extension to Python-Markdown which adds support for shorthand links to GitHub users, repositories, issues and commits."
+conda-forge = "mdx_gh_links"
+pypi = "mdx_gh_links"
+
+
+[[package]]
+description = "A Python library for automating interaction with websites"
+conda-forge = "mechanicalsoup"
+pypi = "MechanicalSoup"
+
+
+[[package]]
+description = "Manifold Learning for Millions of Points"
+conda-forge = "megaman"
+pypi = "megaman"
+
+
+[[package]]
+description = "MEGARA Data Reduction Pipeline"
+conda-forge = "megaradrp"
+pypi = "megaradrp"
+
+
+[[package]]
+description = "A simple python decorator for defining properties that only run their fget function once"
+conda-forge = "memoized-property"
+pypi = "memoized-property"
+
+
+[[package]]
+description = "A module for monitoring memory usage of a python program"
+conda-forge = "memory_profiler"
+pypi = "memory_profiler"
+
+
+[[package]]
+description = "A memory profiler for Python. As easy as adding a decorator."
+conda-forge = "memprof"
+pypi = "memprof"
+
+
+[[package]]
+description = "Spherical mercator and XYZ tile utilities."
+conda-forge = "mercantile"
+pypi = "mercantile"
+
+
+[[package]]
+description = "The Meson Build System"
+conda-forge = "meson"
+pypi = "meson"
+
+
+[[package]]
+description = "A Python implementation of the double metaphone algorithms"
+conda-forge = "metafone"
+pypi = "Metafone"
+
+
+[[package]]
+description = "Metakernel for Jupyter."
+conda-forge = "metakernel"
+pypi = "metakernel"
+
+
+[[package]]
+description = "A Python implementation of the double metaphone algorithms"
+conda-forge = "metaphone"
+pypi = "Metaphone"
+
+
+[[package]]
+description = "A collection of wrappers for functions and classes."
+conda-forge = "metawrap"
+pypi = "metawrap"
+
+
+[[package]]
+description = "MetPy is a collection of tools in Python for reading, visualizing and performing calculations with weather data."
+conda-forge = "metpy"
+pypi = "MetPy"
+
+
+[[package]]
+description = "Meteorology Simulator for Python"
+conda-forge = "metsim"
+pypi = "metsim"
+
+
+[[package]]
+description = "A Python-based micromagnetic model"
+conda-forge = "micromagneticmodel"
+pypi = "micromagneticmodel"
+
+
+[[package]]
+description = "RESTful HTTP Content Negotiation for Flask, Bottle, web.py and webapp2 (Google App Engine)"
+conda-forge = "mimerender"
+pypi = "mimerender"
+
+
+[[package]]
+description = "A CFFI binding for Hoedown, a markdown parsing library."
+conda-forge = "misaka"
+pypi = "misaka"
+
+
+[[package]]
+description = "Missing data visualization module for Python."
+conda-forge = "missingno"
+pypi = "missingno"
+
+
+[[package]]
+description = "The fastest markdown parser in pure Python."
+conda-forge = "mistune"
+pypi = "mistune"
+
+
+[[package]]
+description = "Scales for Python"
+conda-forge = "mizani"
+pypi = "mizani"
+
+
+[[package]]
+description = "Bootstrap theme for MkDocs"
+conda-forge = "mkdocs-bootstrap"
+pypi = "mkdocs-bootstrap"
+
+
+[[package]]
+description = "Bootswatch themes for MkDocs"
+conda-forge = "mkdocs-bootswatch"
+pypi = "mkdocs-bootswatch"
+
+
+[[package]]
+description = "Project documentation with Markdown."
+conda-forge = "mkdocs"
+pypi = "mkdocs"
+
+
+[[package]]
+description = "Machine Learning Library Extensions"
+conda-forge = "mlxtend"
+pypi = "mlxtend"
+
+
+[[package]]
+description = "A decoding library for the PDB mmtf format"
+conda-forge = "mmtf-python"
+pypi = "mmtf-python"
+
+
+[[package]]
+description = "MNE python project for MEG and EEG data analysis."
+conda-forge = "mne"
+pypi = "mne"
+
+
+[[package]]
+description = "A library for testing in Python."
+conda-forge = "mock"
+pypi = "mock"
+
+
+[[package]]
+description = "Modes and nodes for high-order methods"
+conda-forge = "modepy"
+pypi = "modepy"
+
+
+[[package]]
+description = "A hack on top of 2to3 for modernizing code for hybrid codebases."
+conda-forge = "modernize"
+pypi = "modernize"
+
+
+[[package]]
+description = "molPX: Molecular Projection Explorer"
+conda-forge = "molpx"
+pypi = "molPX"
+
+
+[[package]]
+description = "Molecule Validation and Standardization"
+conda-forge = "molvs"
+pypi = "MolVS"
+
+
+[[package]]
+description = "MongoEngine is a Python Object-Document Mapper for working with MongoDB."
+conda-forge = "mongoengine"
+pypi = "mongoengine"
+
+
+[[package]]
+description = "Generating type annotations from sampled production types"
+conda-forge = "monkeytype"
+pypi = "MonkeyType"
+
+
+[[package]]
+description = "An implementation of time.monotonic() for Python 2 & Python 3."
+conda-forge = "monotonic"
+pypi = "monotonic"
+
+
+[[package]]
+description = "Monty is the missing complement to Python."
+conda-forge = "monty"
+pypi = "monty"
+
+
+[[package]]
+description = "Forwarded header support for Morepath"
+conda-forge = "more.forwarded"
+pypi = "more.forwarded"
+
+
+[[package]]
+description = "More routines for operating on iterables, beyond itertools"
+conda-forge = "more-itertools"
+pypi = "more-itertools"
+
+
+[[package]]
+description = "A micro web-framework with superpowers"
+conda-forge = "morepath"
+pypi = "morepath"
+
+
+[[package]]
+description = "Information about path configuration in Morepath"
+conda-forge = "more.pathtool"
+pypi = "more.pathtool"
+
+
+[[package]]
+description = "BowerStatic integration for Morepath"
+conda-forge = "more.static"
+pypi = "more.static"
+
+
+[[package]]
+description = "Library for unsupervised and semi-supervised morphological segmentation"
+conda-forge = "morfessor"
+pypi = "Morfessor"
+
+
+[[package]]
+description = "Modular fitter for astrophysical transients"
+conda-forge = "mosfit"
+pypi = "mosfit"
+
+
+[[package]]
+description = "A library that allows your python tests to easily mock out the boto library."
+conda-forge = "moto"
+pypi = "moto"
+
+
+[[package]]
+description = "Video editing with Python"
+conda-forge = "moviepy"
+pypi = "moviepy"
+
+
+[[package]]
+description = "D3 Viewer for Matplotlib."
+conda-forge = "mpld3"
+pypi = "mpld3"
+
+
+[[package]]
+description = "Convert Matplotlib plots into Leaflet web maps."
+conda-forge = "mplleaflet"
+pypi = "mplleaflet"
+
+
+[[package]]
+description = "Matplotlib helpers to make density scatter plots"
+conda-forge = "mpl-scatter-density"
+pypi = "mpl-scatter-density"
+
+
+[[package]]
+description = "A simple, embeddable Matplotlib-based image viewer."
+conda-forge = "mplview"
+pypi = "mplview"
+
+
+[[package]]
+description = "Python library for arbitrary-precision floating-point arithmetic"
+conda-forge = "mpmath"
+pypi = "mpmath"
+
+
+[[package]]
+description = "Bob renders directory structure templates"
+conda-forge = "mr.bob"
+pypi = "mr.bob"
+
+
+[[package]]
+description = "Python MapReduce framework"
+conda-forge = "mrjob"
+pypi = "mrjob"
+
+
+[[package]]
+description = "Numpy data serialization using msgpack"
+conda-forge = "msgpack-numpy"
+pypi = "msgpack-numpy"
+
+
+[[package]]
+description = "MessagePack (de)serializer."
+conda-forge = "msgpack-python"
+pypi = "msgpack"
+
+
+[[package]]
+description = "Statistical models for Biomolecular Dynamics"
+conda-forge = "msmbuilder"
+pypi = "msmbuilder"
+
+
+[[package]]
+description = "Tools for estimating and analyzing Markov state models"
+conda-forge = "msmtools"
+pypi = "msmtools"
+
+
+[[package]]
+description = "A fast and accurate coalescent simulator."
+conda-forge = "msprime"
+pypi = "msprime"
+
+
+[[package]]
+description = "The runtime library \"msrestazure\" for AutoRest generated Python clients"
+conda-forge = "msrestazure"
+pypi = "msrestazure"
+
+
+[[package]]
+description = "AutoRest swagger generator Python client runtime."
+conda-forge = "msrest"
+pypi = "msrest"
+
+
+[[package]]
+description = "Tools for doing preliminary processing of images from Feder Observatory."
+conda-forge = "msumastro"
+pypi = "msumastro"
+
+
+[[package]]
+description = "Python library for multitaper spectral estimations"
+conda-forge = "mtspec"
+pypi = "mtspec"
+
+
+[[package]]
+description = "multidict implementation"
+conda-forge = "multidict"
+pypi = "multidict"
+
+
+[[package]]
+description = "Multiple dispatch"
+conda-forge = "multipledispatch"
+pypi = "multipledispatch"
+
+
+[[package]]
+description = "better multiprocessing and multithreading in python"
+conda-forge = "multiprocess"
+pypi = "multiprocess"
+
+
+[[package]]
+description = "A multiset implementation for python"
+conda-forge = "multiset"
+pypi = "multiset"
+
+
+[[package]]
+description = "A dot-accessible dictionary (a la JavaScript objects)."
+conda-forge = "munch"
+pypi = "munch"
+
+
+[[package]]
+description = "Tool to work with multiple git repositories"
+conda-forge = "mu_repo"
+pypi = "mu_repo"
+
+
+[[package]]
+description = "Cython bindings for MurmurHash2"
+conda-forge = "murmurhash"
+pypi = "murmurhash"
+
+
+[[package]]
+description = "Generic tools to identify overlapping genomic regions"
+conda-forge = "murphy"
+pypi = "murphy"
+
+
+[[package]]
+description = "Read and write audio tags for many formats"
+conda-forge = "mutagen"
+pypi = "mutagen"
+
+
+[[package]]
+description = "MediaWiki API client"
+conda-forge = "mwclient"
+pypi = "mwclient"
+
+
+[[package]]
+description = "MyProxy Client"
+conda-forge = "myproxyclient"
+pypi = "MyProxyClient"
+
+
+[[package]]
+description = "Experimental type system extensions for programs checked with the mypy typechecker."
+conda-forge = "mypy_extensions"
+pypi = "mypy_extensions"
+
+
+[[package]]
+description = "Optional static typing for Python"
+conda-forge = "mypy"
+pypi = "mypy"
+
+
+[[package]]
+description = "Derivation of non-thermal particle distributions through MCMC spectral fitting"
+conda-forge = "naima"
+pypi = "naima"
+
+
+[[package]]
+description = "Similar to namedtuple, but instances are mutable."
+conda-forge = "namedlist"
+pypi = "f7db251a949311c4f09f583e1b3c5a7e377220d5913607e6ab453446fe7e"
+
+
+[[package]]
+description = "Sort lists naturally"
+conda-forge = "natsort"
+pypi = "natsort"
+
+
+[[package]]
+description = "LaTeX-free PDF generation from Jupyter Notebooks"
+conda-forge = "nbbrowserpdf"
+pypi = "nbbrowserpdf"
+
+
+[[package]]
+description = "Converting Jupyter Notebooks"
+conda-forge = "nbconvert"
+pypi = "nbconvert"
+
+
+[[package]]
+description = "Diff and merge of Jupyter Notebooks"
+conda-forge = "nbdime"
+pypi = "nbdime"
+
+
+[[package]]
+description = "Importing Jupyter Notebooks as Modules"
+conda-forge = "nbfinder"
+pypi = "nbfinder"
+
+
+[[package]]
+description = "The Jupyter Notebook format"
+conda-forge = "nbformat"
+pypi = "nbformat"
+
+
+[[package]]
+description = "Jupyter extension to proxy RStudio's rsession"
+conda-forge = "nbrsessionproxy"
+pypi = "nbrsessionproxy"
+
+
+[[package]]
+description = "Jupyter server extension to proxy web services"
+conda-forge = "nbserverproxy"
+pypi = "nbserverproxy"
+
+
+[[package]]
+description = "Basic notebook checks. Do they run? Do they contain lint?"
+conda-forge = "nbsmoke"
+pypi = "nbsmoke"
+
+
+[[package]]
+description = "Jupyter Notebook Tools for Sphinx"
+conda-forge = "nbsphinx"
+pypi = "nbsphinx"
+
+
+[[package]]
+description = "strip output from Jupyter and IPython notebooks"
+conda-forge = "nbstripout"
+pypi = "nbstripout"
+
+
+[[package]]
+description = "A py.test plugin to validate Jupyter notebooks"
+conda-forge = "nbval"
+pypi = "nbval"
+
+
+[[package]]
+description = "Python interface for the Cephes library"
+conda-forge = "ncephes"
+pypi = "ncephes"
+
+
+[[package]]
+description = "Solve global polynomial optimization problems of either commutative variables or noncommutative operators through a semidefinite programming (SDP) relaxation"
+conda-forge = "ncpol2sdpa"
+pypi = "ncpol2sdpa"
+
+
+[[package]]
+description = "Pure Python library for reading NIS Elements ND2 images and metadata"
+conda-forge = "nd2reader"
+pypi = "nd2reader"
+
+
+[[package]]
+description = "Implementation of the Observer pattern for NumPy arrays."
+conda-forge = "ndarray-listener"
+pypi = "ndarray_listener"
+
+
+[[package]]
+description = "A base package for multi-dimensional contiguious and non-contiguious spatially aware arrays."
+conda-forge = "ndcube"
+pypi = "ndcube"
+
+
+[[package]]
+description = "Provides enhanced HTTPS support for httplib and urllib2 using PyOpenSSL."
+conda-forge = "ndg-httpsclient"
+pypi = "ndg-httpsclient"
+
+
+[[package]]
+description = "An object mapper for the neo4j graph database."
+conda-forge = "neomodel"
+pypi = "neomodel"
+
+
+[[package]]
+description = "Nanosecond resolution temporal types"
+conda-forge = "neotime"
+pypi = "neotime"
+
+
+[[package]]
+description = "Python client to neovim"
+conda-forge = "neovim"
+pypi = "neovim"
+
+
+[[package]]
+description = "A collection of functions designed to make running software with combinatorial choices of parameters easier."
+conda-forge = "nestly"
+pypi = "nestly"
+
+
+[[package]]
+description = "Pythonic manipulation of IPv4, IPv6, CIDR, EUI and MAC network addresses"
+conda-forge = "netaddr"
+pypi = "netaddr"
+
+
+[[package]]
+description = "Time-handling functionality from netcdf4-python"
+conda-forge = "cftime"
+pypi = "cftime"
+
+
+[[package]]
+description = "Portable network interface information."
+conda-forge = "netifaces"
+pypi = "netifaces"
+
+
+[[package]]
+description = "Python package for creating and manipulating complex networks"
+conda-forge = "networkx"
+pypi = "networkx"
+
+
+[[package]]
+description = "Neutron Imaging Normalization Library"
+conda-forge = "neunorm"
+pypi = "NeuNorm"
+
+
+[[package]]
+description = "New Relic Python Agent"
+conda-forge = "newrelic"
+pypi = "newrelic"
+
+
+[[package]]
+description = "Simplified python article discovery & extraction."
+conda-forge = "newspaper3k"
+pypi = "newspaper3k"
+
+
+[[package]]
+description = "An IPython widget to interactively view molecular structures and trajectories. Utilizes the embeddable NGL Viewer for rendering."
+conda-forge = "nglview"
+pypi = "nglview"
+
+
+[[package]]
+description = "Statistical learning for neuroimaging in Python"
+conda-forge = "nilearn"
+pypi = "nilearn"
+
+
+[[package]]
+description = "Python module for generating .ninja files."
+conda-forge = "ninja_syntax"
+pypi = "ninja_syntax"
+
+
+[[package]]
+description = "Neuroimaging in Python FMRI analysis package"
+conda-forge = "nipy"
+pypi = "nipy"
+
+
+[[package]]
+description = "Timeseries analysis for neuroscience data"
+conda-forge = "nitime"
+pypi = "nitime"
+
+
+[[package]]
+description = "Natural Language Toolkit"
+conda-forge = "nltk"
+pypi = "nltk"
+
+
+[[package]]
+description = "The node2vec algorithm learns continuous representations for nodes in any (un)directed, (un)weighted graph."
+conda-forge = "node2vec"
+pypi = "node2vec"
+
+
+[[package]]
+description = "nose2 is the next generation of nicer testing for Python"
+conda-forge = "nose2"
+pypi = "nose2"
+
+
+[[package]]
+description = "nose plugin for coverage reporting, including subprocesses and multiprocessing"
+conda-forge = "nose-cov"
+pypi = "nose-cov"
+
+
+[[package]]
+description = "Parameterized testing with any Python test framework."
+conda-forge = "nose-parameterized"
+pypi = "nose-parameterized"
+
+
+[[package]]
+description = "A nosetests plugin with a progress bar and an emphasis on showing what is important"
+conda-forge = "nose-progressive"
+pypi = "nose-progressive"
+
+
+[[package]]
+description = "Nose extends unittest to make testing easier"
+conda-forge = "nose"
+pypi = "nose"
+
+
+[[package]]
+description = "A timer plugin for nosetests."
+conda-forge = "nose-timer"
+pypi = "nose-timer"
+
+
+[[package]]
+description = "Extends nose.plugins.cover to add Cobertura-style XML reports"
+conda-forge = "nosexcover"
+pypi = "nosexcover"
+
+
+[[package]]
+description = "A web-based notebook environment for interactive computing"
+conda-forge = "notebook"
+pypi = "notebook"
+
+
+[[package]]
+description = "Convert markdown to IPython notebook."
+conda-forge = "notedown"
+pypi = "notedown"
+
+
+[[package]]
+description = "Python utility functions for slices."
+conda-forge = "npctypes"
+pypi = "npctypes"
+
+
+[[package]]
+description = "Streaming operations on NumPy arrays"
+conda-forge = "npstreams"
+pypi = "npstreams"
+
+
+[[package]]
+description = "Calculates NTLM Authentication codes"
+conda-forge = "ntlm-auth"
+pypi = "ntlm-auth"
+
+
+[[package]]
+description = "This module offers a simple interface to query NTP servers from Python."
+conda-forge = "ntplib"
+pypi = "ntplib"
+
+
+[[package]]
+description = "Python compiler with full language support and CPython compatibility"
+conda-forge = "nuitka"
+pypi = "Nuitka"
+
+
+[[package]]
+description = "NumPy aware dynamic Python compiler using LLVM"
+conda-forge = "numba"
+pypi = "numba"
+
+
+[[package]]
+description = "A Python package providing buffer compression and transformation codecs for use in data storage and communication applications."
+conda-forge = "numcodecs"
+pypi = "numcodecs"
+
+
+[[package]]
+description = "Solves automatic numerical differentiation problems in one or more variables."
+conda-forge = "numdifftools"
+pypi = "numdifftools"
+
+
+[[package]]
+description = "Fast numerical expression evaluator for NumPy."
+conda-forge = "numexpr"
+pypi = "numexpr"
+
+
+[[package]]
+description = "Astronomy data reduction library"
+conda-forge = "numina"
+pypi = "numina"
+
+
+[[package]]
+description = "Numpy's Sphinx extensions"
+conda-forge = "numpydoc"
+pypi = "numpydoc"
+
+
+[[package]]
+description = "Optimised tools for group-indexing operations: aggregated sum and more."
+conda-forge = "numpy_groupies"
+pypi = "numpy_groupies"
+
+
+[[package]]
+description = "Missing NumPy functionalities"
+conda-forge = "numpy-sugar"
+pypi = "numpy-sugar"
+
+
+[[package]]
+description = "Rational network visualizations in Python"
+conda-forge = "nxviz"
+pypi = "nxviz"
+
+
+[[package]]
+description = "OAuth 2.0 client library"
+conda-forge = "oauth2client"
+pypi = "oauth2client"
+
+
+[[package]]
+description = "A generic, spec-compliant, thorough implementation of the OAuth request-signing logic"
+conda-forge = "oauthlib"
+pypi = "oauthlib"
+
+
+[[package]]
+description = "ObsPy: A Python Toolbox for seismology/seismological observatories."
+conda-forge = "obspy"
+pypi = "obspy"
+
+
+[[package]]
+description = "Python to GNU Octave bridge --> run m-files from python."
+conda-forge = "oct2py"
+pypi = "oct2py"
+
+
+[[package]]
+description = "A Jupyter kernel for Octave."
+conda-forge = "octave_kernel"
+pypi = "octave_kernel"
+
+
+[[package]]
+description = "A library for simplifying the process of climate model evaluation."
+conda-forge = "ocw"
+pypi = "ocw"
+
+
+[[package]]
+description = "Python API and tools to manipulate OpenDocument files."
+conda-forge = "odfpy"
+pypi = "odfpy"
+
+
+[[package]]
+description = "Ocean Dimensionless Vertical Coordinates"
+conda-forge = "odvc"
+pypi = "odvc"
+
+
+[[package]]
+description = "Tools for observing the terrestrial and aquatic surfaces of Earth"
+conda-forge = "ogh"
+pypi = "ogh"
+
+
+[[package]]
+description = "Python package to parse, read and write Microsoft OLE2 files (Structured Storage or Compound Document, Microsoft Office) - Improved version of the OleFileIO module from PIL, the Python Image Library.\n"
+conda-forge = "olefile"
+pypi = "olefile"
+
+
+[[package]]
+description = "Ordered Multidimensional Array Structure"
+conda-forge = "omas"
+pypi = "omas"
+
+
+[[package]]
+description = "Omnifit - astronomical ice spectroscopy fitting"
+conda-forge = "omnifit"
+pypi = "omnifit"
+
+
+[[package]]
+description = "Caffe2 implementation of Open Neural Network Exchange (ONNX)"
+conda-forge = "onnx-caffe2"
+pypi = "onnx-caffe2"
+
+
+[[package]]
+description = "Open Neural Network Exchange library"
+conda-forge = "onnx"
+pypi = "onnx"
+
+
+[[package]]
+description = "Experimental Tensorflow Backend for ONNX"
+conda-forge = "onnx-tf"
+pypi = "onnx-tf"
+
+
+[[package]]
+description = "A Python interface to the OOMMF micromagnetic calculator"
+conda-forge = "oommfc"
+pypi = "oommfc"
+
+
+[[package]]
+description = "Reading and analysing OOMMF odt files"
+conda-forge = "oommfodt"
+pypi = "oommfodt"
+
+
+[[package]]
+description = "Python agent for Opbeat."
+conda-forge = "opbeat"
+pypi = "opbeat"
+
+
+[[package]]
+description = "A Python library to read/write Excel 2010 xlsx/xlsm files"
+conda-forge = "openpyxl"
+pypi = "openpyxl"
+
+
+[[package]]
+description = "Computes earthquake hazard and risk."
+conda-forge = "openquake.engine"
+pypi = "openquake.engine"
+
+
+[[package]]
+description = "Collection of libraries for building applications to work with OpenStack clouds."
+conda-forge = "openstacksdk"
+pypi = "openstacksdk"
+
+
+[[package]]
+description = "Tracing Instrumentation using OpenTracing API (http://opentracing.io)"
+conda-forge = "opentracing_instrumentation"
+pypi = "opentracing_instrumentation"
+
+
+[[package]]
+description = "OpenTracing API for Python."
+conda-forge = "opentracing"
+pypi = "opentracing"
+
+
+[[package]]
+description = "Abstract function optimisation"
+conda-forge = "optimix"
+pypi = "optimix"
+
+
+[[package]]
+description = "optlang - sympy based mathematical programming language"
+conda-forge = "optlang"
+pypi = "optlang"
+
+
+[[package]]
+description = "Tools for optimizing dynamic systems using direct collocation."
+conda-forge = "opty"
+pypi = "opty"
+
+
+[[package]]
+description = "Orange3 add-on with common functionality for bioinformatics"
+conda-forge = "orange3-bioinformatics"
+pypi = "Orange3-Bioinformatics"
+
+
+[[package]]
+description = "Educational widgets for machine learning and data mining in Orange 3."
+conda-forge = "orange3-educational"
+pypi = "Orange3-Educational"
+
+
+[[package]]
+description = "Orange add-on for dealing with geography and geo-location"
+conda-forge = "orange3-geo"
+pypi = "Orange3-Geo"
+
+
+[[package]]
+description = "Orange3 add-on for dealing with image related tasks"
+conda-forge = "orange3-imageanalytics"
+pypi = "Orange3-ImageAnalytics"
+
+
+[[package]]
+description = "Networks add-on for Orange 3 data mining software package."
+conda-forge = "orange3-network"
+pypi = "Orange3-Network"
+
+
+[[package]]
+description = "Orange3 add-on for analyzing textual data."
+conda-forge = "orange3-text"
+pypi = "Orange3-Text"
+
+
+[[package]]
+description = "Orange3 add-on for exploring time series and sequential data."
+conda-forge = "orange3-timeseries"
+pypi = "Orange3-Timeseries"
+
+
+[[package]]
+description = "Python wrapper around ORCID API"
+conda-forge = "orcid"
+pypi = "orcid"
+
+
+[[package]]
+description = "Ordered Multivalue Dictionary - omdict."
+conda-forge = "orderedmultidict"
+pypi = "orderedmultidict"
+
+
+[[package]]
+description = "A MutableSet that remembers its order, so that every entry has an index."
+conda-forge = "ordered-set"
+pypi = "ordered-set"
+
+
+[[package]]
+description = "An Ordered Set implementation in Cython."
+conda-forge = "orderedset"
+pypi = "orderedset"
+
+
+[[package]]
+description = "OpenStack Client Configuation Library"
+conda-forge = "os-client-config"
+pypi = "os-client-config"
+
+
+[[package]]
+description = "Set that remembers original insertion order"
+conda-forge = "oset"
+pypi = "oset"
+
+
+[[package]]
+description = "An OSF command-line library."
+conda-forge = "osfclient"
+pypi = "osfclient"
+
+
+[[package]]
+description = "The Oslo configuration API supports parsing command line arguments and .ini style configuration files."
+conda-forge = "oslo.config"
+pypi = "oslo.config"
+
+
+[[package]]
+description = "Utilities for working with internationalization (i18n) features, especially translation for text strings in an application or library."
+conda-forge = "oslo.i18n"
+pypi = "oslo.i18n"
+
+
+[[package]]
+description = "Oslo Serialization library"
+conda-forge = "oslo.serialization"
+pypi = "oslo.serialization"
+
+
+[[package]]
+description = "Support for common utility type functions, such as encoding, exception handling, string manipulation, and time handling."
+conda-forge = "oslo.utils"
+pypi = "oslo.utils"
+
+
+[[package]]
+description = "Python wrapper for the OSM API"
+conda-forge = "osmapi"
+pypi = "osmapi"
+
+
+[[package]]
+description = "Retrieve, construct, analyze, and visualize street networks from OpenStreetMap"
+conda-forge = "osmnx"
+pypi = "osmnx"
+
+
+[[package]]
+description = "Summary of the package"
+conda-forge = "os-service-types"
+pypi = "os-service-types"
+
+
+[[package]]
+description = "Python Wrapper to access the OpenStreepMap Overpass API"
+conda-forge = "overpy"
+pypi = "overpy"
+
+
+[[package]]
+description = "A decorator to automatically detect mismatch when overriding a method."
+conda-forge = "overrides"
+pypi = "overrides"
+
+
+[[package]]
+description = "OGC Web Service utility library."
+conda-forge = "owslib"
+pypi = "OWSLib"
+
+
+[[package]]
+description = "Core utilities for Python packages"
+conda-forge = "packaging"
+pypi = "packaging"
+
+
+[[package]]
+description = "Paegan - The Python CDM for Met/Ocean data."
+conda-forge = "paegan"
+pypi = "paegan"
+
+
+[[package]]
+description = "Color palettes for Python."
+conda-forge = "palettable"
+pypi = "palettable"
+
+
+[[package]]
+description = "PAM interface using ctypes"
+conda-forge = "pamela"
+pypi = "pamela"
+
+
+[[package]]
+description = "Pandas API compatibility layer"
+conda-forge = "pandas-compat"
+pypi = "pandas-compat"
+
+
+[[package]]
+description = "Up to date remote data access for pandas, works for multiple versions of pandas"
+conda-forge = "pandas-datareader"
+pypi = "pandas-datareader"
+
+
+[[package]]
+description = "Pandas interface to Google Big Query"
+conda-forge = "pandas-gbq"
+pypi = "pandas-gbq"
+
+
+[[package]]
+description = "pandas-highcharts is a Python package which allows you to easily build Highcharts plots with pandas.DataFrame objects."
+conda-forge = "pandas-highcharts"
+pypi = "pandas-highcharts"
+
+
+[[package]]
+description = "pandas, scikit-learn and xgboost integration"
+conda-forge = "pandas_ml"
+pypi = "pandas_ml"
+
+
+[[package]]
+description = "Pandas interface to msgpack"
+conda-forge = "pandas-msgpack"
+pypi = "pandas-msgpack"
+
+
+[[package]]
+description = "Convert PLINK files to Pandas data frame"
+conda-forge = "pandas-plink"
+pypi = "pandas-plink"
+
+
+[[package]]
+description = "Generate profile report for pandas DataFrame"
+conda-forge = "pandas-profiling"
+pypi = "pandas-profiling"
+
+
+[[package]]
+description = "An extension to pandas describe function."
+conda-forge = "pandas-summary"
+pypi = "pandas-summary"
+
+
+[[package]]
+description = "A simple parser / emitter for pandoc block attributes, intended for use with pandocfilters."
+conda-forge = "pandoc-attributes"
+pypi = "pandoc-attributes"
+
+
+[[package]]
+description = "A python module for writing pandoc filters"
+conda-forge = "pandocfilters"
+pypi = "pandocfilters"
+
+
+[[package]]
+description = "GROMACS edr files to pandas dataframe"
+conda-forge = "panedr"
+pypi = "panedr"
+
+
+[[package]]
+description = "An xarray extension for land surface models."
+conda-forge = "pangaea"
+pypi = "pangaea"
+
+
+[[package]]
+description = "A Python module to read and plot cuffdiff/Galaxy RNA-seq data"
+conda-forge = "papillon"
+pypi = "papillon"
+
+
+[[package]]
+description = "Parameterized testing with any Python test framework"
+conda-forge = "parameterized"
+pypi = "parameterized"
+
+
+[[package]]
+description = "SSH2 protocol library"
+conda-forge = "paramiko"
+pypi = "paramiko"
+
+
+[[package]]
+description = "Param: Make your Python code clearer and more reliable by declaring Parameters"
+conda-forge = "param"
+pypi = "param"
+
+
+[[package]]
+description = "Parameterization Framework for parameterized model creation and handling."
+conda-forge = "paramz"
+pypi = "paramz"
+
+
+[[package]]
+description = "Parse human-readable date/time text."
+conda-forge = "parsedatetime"
+pypi = "parsedatetime"
+
+
+[[package]]
+description = "parse() is the opposite of format()"
+conda-forge = "parse"
+pypi = "parse"
+
+
+[[package]]
+description = "Simplifies to build parse types based on the parse module"
+conda-forge = "parse_type"
+pypi = "parse_type"
+
+
+[[package]]
+description = "A Python Parser"
+conda-forge = "parso"
+pypi = "parso"
+
+
+[[package]]
+description = "Data structure for on-disk shuffle operations"
+conda-forge = "partd"
+pypi = "partd"
+
+
+[[package]]
+description = "comprehensive password hashing framework supporting over 30 schemes"
+conda-forge = "passlib"
+pypi = "passlib"
+
+
+[[package]]
+description = "Bring colors to your terminal."
+conda-forge = "pastel"
+pypi = "pastel"
+
+
+[[package]]
+description = "Functions for server CLI applications used by humans."
+conda-forge = "path-and-address"
+pypi = "path-and-address"
+
+
+[[package]]
+description = "Fork of pathlib aiming to support the full stdlib Python API."
+conda-forge = "pathlib2"
+pypi = "pathlib2"
+
+
+[[package]]
+description = "Object-oriented filesystem paths"
+conda-forge = "pathlib"
+pypi = "pathlib"
+
+
+[[package]]
+description = "parallel graph management and execution in heterogeneous computing"
+conda-forge = "pathos"
+pypi = "pathos"
+
+
+[[package]]
+description = "A module wrapper for os.path"
+conda-forge = "path.py"
+pypi = "path.py"
+
+
+[[package]]
+description = "Path utilities for Python."
+conda-forge = "pathtools"
+pypi = "pathtools"
+
+
+[[package]]
+description = "portable archive file manager"
+conda-forge = "patool"
+pypi = "patool"
+
+
+[[package]]
+description = "Describing statistical models in Python using symbolic formulas"
+conda-forge = "patsy"
+pypi = "patsy"
+
+
+[[package]]
+description = "Easy build, distribution and deployment scripting"
+conda-forge = "paver"
+pypi = "Paver"
+
+
+[[package]]
+description = "Python Build Reasonableness"
+conda-forge = "pbr"
+pypi = "pbr"
+
+
+[[package]]
+description = "pdb++, a drop-in replacement for pdb"
+conda-forge = "pdbpp"
+pypi = "pdbpp"
+
+
+[[package]]
+description = "pdfminer3k is a Python 3 port of pdfminer — a tool for extracting information from PDF documents"
+conda-forge = "pdfminer3k"
+pypi = "pdfminer3k"
+
+
+[[package]]
+description = "PDF parser and analyzer"
+conda-forge = "pdfminer.six"
+pypi = "pdfminer.six"
+
+
+[[package]]
+description = "Pretty dir printing with joy"
+conda-forge = "pdir2"
+pypi = "pdir2"
+
+
+[[package]]
+description = "Peak detection utilities for 1D data"
+conda-forge = "peakutils"
+pypi = "PeakUtils"
+
+
+[[package]]
+description = "A little ORM"
+conda-forge = "peewee"
+pypi = "peewee"
+
+
+[[package]]
+description = "pefile is a Python module to read and work with PE (Portable Executable) files"
+conda-forge = "pefile"
+pypi = "pefile"
+
+
+[[package]]
+description = "A tool to generate a static blog from reStructuredText or Markdown input files."
+conda-forge = "pelican"
+pypi = "pelican"
+
+
+[[package]]
+description = "Python datetimes made easy"
+conda-forge = "pendulum"
+pypi = "pendulum"
+
+
+[[package]]
+description = "Python docstring style checker (replaced by pydocstyle)"
+conda-forge = "pep257"
+pypi = "pep257"
+
+
+[[package]]
+description = "Plug-in for flake 8 to check the PEP-8 naming conventions"
+conda-forge = "pep8-naming"
+pypi = "pep8-naming"
+
+
+[[package]]
+description = "Python style guide checker"
+conda-forge = "pep8"
+pypi = "pep8"
+
+
+[[package]]
+description = "Extensible periodic table for python"
+conda-forge = "periodictable"
+pypi = "periodictable"
+
+
+[[package]]
+description = "Simple and flexible permission control for Flask-style apps"
+conda-forge = "permission"
+pypi = "permission"
+
+
+[[package]]
+description = "Multiplex generators for incremental learning"
+conda-forge = "pescador"
+pypi = "pescador"
+
+
+[[package]]
+description = "A Python package for extracting, transforming and loading tables of data."
+conda-forge = "petl"
+pypi = "petl"
+
+
+[[package]]
+description = "Pexpect makes Python a better tool for controlling other applications."
+conda-forge = "pexpect"
+pypi = "pexpect"
+
+
+[[package]]
+description = "CLI for Postgres Database. With auto-completion and syntax highlighting."
+conda-forge = "pgcli"
+pypi = "pgcli"
+
+
+[[package]]
+description = "Meta-commands handler for Postgres Database."
+conda-forge = "pgspecial"
+pypi = "pgspecial"
+
+
+[[package]]
+description = "Python version of Google's common library for parsing, formatting, storing and validating international phone numbers."
+conda-forge = "phonenumbers"
+pypi = "phonenumbers"
+
+
+[[package]]
+description = "Phonopy is an open source package for phonon calculations at harmonic and quasi-harmonic levels."
+conda-forge = "phonopy"
+pypi = "phonopy"
+
+
+[[package]]
+description = "An Astropy package for photometry"
+conda-forge = "photutils"
+pypi = "photutils"
+
+
+[[package]]
+description = "Python tools for PHREEQC"
+conda-forge = "phreeqpy"
+pypi = "phreeqpy"
+
+
+[[package]]
+description = "Tiny 'shelve'-like database with concurrency support"
+conda-forge = "pickleshare"
+pypi = "pickleshare"
+
+
+[[package]]
+description = "IDL within Python"
+conda-forge = "pidly"
+pypi = "pIDLy"
+
+
+[[package]]
+description = "The simplest way to write one program that runs on both Python 2 and Python 3."
+conda-forge = "pies"
+pypi = "pies"
+
+
+[[package]]
+description = "Pure Python RabbitMQ/AMQP 0-9-1 client library"
+conda-forge = "pika"
+pypi = "pika"
+
+
+[[package]]
+description = "Pillow is the friendly PIL fork by Alex Clark and Contributors."
+conda-forge = "pillow"
+pypi = "Pillow"
+
+
+[[package]]
+description = "Python Image Sequence. Load video and sequential images in many formats with a simple, consistent interface.\n"
+conda-forge = "pims"
+pypi = "PIMS"
+
+
+[[package]]
+description = "A graphical user interface (GUI) for PIMS"
+conda-forge = "pimsviewer"
+pypi = "pimsviewer"
+
+
+[[package]]
+description = "Operate and manipulate physical quantities in Python"
+conda-forge = "pint"
+pypi = "Pint"
+
+
+[[package]]
+description = "Pipfile: the replacement for requirements.txt"
+conda-forge = "pipfile"
+pypi = "pipfile"
+
+
+[[package]]
+description = "PyPA recommended tool for installing Python packages"
+conda-forge = "pip"
+pypi = "pip"
+
+
+[[package]]
+description = "Pip requirements.txt generator based on imports in project"
+conda-forge = "pipreqs"
+pypi = "pipreqs"
+
+
+[[package]]
+description = "Query metadatdata from sdists / bdists / installed packages."
+conda-forge = "pkginfo"
+pypi = "pkginfo"
+
+
+[[package]]
+description = "The smartest command line arguments parser in the world"
+conda-forge = "plac"
+pypi = "plac"
+
+
+[[package]]
+description = "Python PDS and Isis Cube file parser."
+conda-forge = "planetaryimage"
+pypi = "planetaryimage"
+
+
+[[package]]
+description = "Planet API Client"
+conda-forge = "planet"
+pypi = "planet"
+
+
+[[package]]
+description = "Multiobjective optimization in Python"
+conda-forge = "platypus-opt"
+pypi = "Platypus-Opt"
+
+
+[[package]]
+description = "An interactive, browser-based graphing library for Python"
+conda-forge = "plotly"
+pypi = "plotly"
+
+
+[[package]]
+description = "A grammar of graphics for python"
+conda-forge = "plotnine"
+pypi = "plotnine"
+
+
+[[package]]
+description = "Plugin registration and hook calling for Python"
+conda-forge = "pluggy"
+pypi = "pluggy"
+
+
+[[package]]
+description = "A support library for building plugins sytems in Python."
+conda-forge = "pluginbase"
+pypi = "pluginbase"
+
+
+[[package]]
+description = "Plumbum: shell combinators library"
+conda-forge = "plumbum"
+pypi = "plumbum"
+
+
+[[package]]
+description = "Python Lex-Yacc"
+conda-forge = "ply"
+pypi = "ply"
+
+
+[[package]]
+description = "Toolkit for building high-level compound widgets in Python using the Tkinter module."
+conda-forge = "pmw"
+pypi = "Pmw"
+
+
+[[package]]
+description = "Python Optimization Asynchronous Plumbing."
+conda-forge = "poap"
+pypi = "POAP"
+
+
+[[package]]
+description = "API wrapper for getpocket.com"
+conda-forge = "pocket"
+pypi = "pocket"
+
+
+[[package]]
+description = "A python utility library for interacting with NASA JPLs PO.DAAC"
+conda-forge = "podaacpy"
+pypi = "podaacpy"
+
+
+[[package]]
+description = "A small utility for converting between polarand cartesian units."
+conda-forge = "polcart"
+pypi = "polcart"
+
+
+[[package]]
+description = "A library to manipulate gettext files (po and mo files)."
+conda-forge = "polib"
+pypi = "polib"
+
+
+[[package]]
+description = "A Python implementation of Google's Encoded Polyline Algorithm Format."
+conda-forge = "polyline"
+pypi = "polyline"
+
+
+[[package]]
+description = "Pony is a Python Object Relational Mapper (ORM) with beautiful query syntax."
+conda-forge = "pony"
+pypi = "pony"
+
+
+[[package]]
+description = "Portalocker is a library to provide an easy API to file locking."
+conda-forge = "portalocker"
+pypi = "portalocker"
+
+
+[[package]]
+description = "TCP port monitoring utilities"
+conda-forge = "portend"
+pypi = "portend"
+
+
+[[package]]
+description = "port-for is a command-line utility and a python library that helps with local TCP ports managment"
+conda-forge = "port-for"
+pypi = "port-for"
+
+
+[[package]]
+description = "Library to enforce positional or key-word arguments"
+conda-forge = "positional"
+pypi = "positional"
+
+
+[[package]]
+description = "Python Optimal Transport library"
+conda-forge = "pot"
+pypi = "POT"
+
+
+[[package]]
+description = "Powerline is a statusline plugin for vim"
+conda-forge = "powerline-status"
+pypi = "powerline-status"
+
+
+[[package]]
+description = "utilities for filesystem exploration and automated builds"
+conda-forge = "pox"
+pypi = "pox"
+
+
+[[package]]
+description = "A lightweight YAML Parser for Python"
+conda-forge = "poyo"
+pypi = "poyo"
+
+
+[[package]]
+description = "A compiler for ARM, X86, MSP430, xtensa and more implemented in pure Python"
+conda-forge = "ppci"
+pypi = "ppci"
+
+
+[[package]]
+description = "distributed and parallel python"
+conda-forge = "ppft"
+pypi = "ppft"
+
+
+[[package]]
+description = "Line-granularity, thread-aware deterministic and statistic pure-python profiler"
+conda-forge = "pprofile"
+pypi = "pprofile"
+
+
+[[package]]
+description = "Low-level communication layer for PRAW 4+"
+conda-forge = "prawcore"
+pypi = "prawcore"
+
+
+[[package]]
+description = "Python Reddit API Wrapper allows for simple access to Reddit's API"
+conda-forge = "praw"
+pypi = "praw"
+
+
+[[package]]
+description = "Turns CSS blocks into style attributes"
+conda-forge = "premailer"
+pypi = "premailer"
+
+
+[[package]]
+description = "Cython Hash Table for Pre-Hashed Keys"
+conda-forge = "preshed"
+pypi = "preshed"
+
+
+[[package]]
+description = "A library for stubbing in Python"
+conda-forge = "pretend"
+pypi = "pretend"
+
+
+[[package]]
+description = "A simple Python library for easily displaying tabular data in a visually appealing ASCII table format"
+conda-forge = "prettytable"
+pypi = "prettytable"
+
+
+[[package]]
+description = "Common methods for probable parsing"
+conda-forge = "probableparsing"
+pypi = "probableparsing"
+
+
+[[package]]
+description = "Python imports tracer"
+conda-forge = "profimp"
+pypi = "profimp"
+
+
+[[package]]
+description = "A Python Progressbar library to provide visual (yet text based) progress to long running operations."
+conda-forge = "progressbar2"
+pypi = "progressbar2"
+
+
+[[package]]
+description = "Text progress bar library for Python."
+conda-forge = "progressbar33"
+pypi = "progressbar33"
+
+
+[[package]]
+description = "Easy progress reporting for Python"
+conda-forge = "progress"
+pypi = "progress"
+
+
+[[package]]
+description = "Python interface for progress reporting"
+conda-forge = "progress_reporter"
+pypi = "progress-reporter"
+
+
+[[package]]
+description = "Ultra-performant Promise implementation in Python"
+conda-forge = "promise"
+pypi = "promise"
+
+
+[[package]]
+description = "Library for prompting input on the command line"
+conda-forge = "prompt"
+pypi = "prompt"
+
+
+[[package]]
+description = "Library for building powerful interactive command lines in Python"
+conda-forge = "prompt_toolkit"
+pypi = "prompt_toolkit"
+
+
+[[package]]
+description = "A Python library for creating optimized, repeatable and self-documenting data analysis pipelines."
+conda-forge = "proof"
+pypi = "proof"
+
+
+[[package]]
+description = "documentation, validation, tab completion, serialization of properties"
+conda-forge = "properties"
+pypi = "properties"
+
+
+[[package]]
+description = "Prospector: python static analysis tool"
+conda-forge = "prospector"
+pypi = "prospector"
+
+
+[[package]]
+description = "library for transpiling Python code to JavaScript."
+conda-forge = "pscript"
+pypi = "pscript"
+
+
+[[package]]
+description = "A cross-platform process and system utilities module for Python"
+conda-forge = "psutil"
+pypi = "psutil"
+
+
+[[package]]
+description = "psycopg2 integration with coroutine libraries"
+conda-forge = "psycogreen"
+pypi = "psycogreen"
+
+
+[[package]]
+description = "Python-PostgreSQL Database Adapter"
+conda-forge = "psycopg2"
+pypi = "psycopg2"
+
+
+[[package]]
+description = "Psyplot plugin for visualization on a map"
+conda-forge = "psy-maps"
+pypi = "psy-maps"
+
+
+[[package]]
+description = "Graphical user interface for the psyplot package"
+conda-forge = "psyplot-gui"
+pypi = "psyplot-gui"
+
+
+[[package]]
+description = "Python package for interactive data visualization"
+conda-forge = "psyplot"
+pypi = "psyplot"
+
+
+[[package]]
+description = "Psyplot plugin for visualizing and calculating regression plots"
+conda-forge = "psy-reg"
+pypi = "psy-reg"
+
+
+[[package]]
+description = "Psyplot plugin for simple visualization tasks"
+conda-forge = "psy-simple"
+pypi = "psy-simple"
+
+
+[[package]]
+description = "Run a subprocess in a pseudo terminal"
+conda-forge = "ptyprocess"
+pypi = "ptyprocess"
+
+
+[[package]]
+description = "A full-screen, console-based Python debugger"
+conda-forge = "pudb"
+pypi = "pudb"
+
+
+[[package]]
+description = "PuLP is an LP modeler written in python. PuLP can generate MPS or LP files\nand call GLPK, COIN CLP/CBC, CPLEX, and GUROBI to solve linear problems.\n"
+conda-forge = "pulp"
+pypi = "PuLP"
+
+
+[[package]]
+description = "Pure Python library for PNG image encoding/decoding"
+conda-forge = "purepng"
+pypi = "purepng"
+
+
+[[package]]
+description = "A pure python SASL client"
+conda-forge = "pure-sasl"
+pypi = "pure-sasl"
+
+
+[[package]]
+description = "A set functions and classes for simulating the performance of photovoltaic energy systems."
+conda-forge = "pvlib-python"
+pypi = "pvlib"
+
+
+[[package]]
+description = "Python implementation of PVL (Parameter Value Language)"
+conda-forge = "pvl"
+pypi = "pvl"
+
+
+[[package]]
+description = "Scientific reports with embedded python computations with reST, LaTeX or markdown"
+conda-forge = "pweave"
+pypi = "pweave"
+
+
+[[package]]
+description = "Miscellaneous scientific and astronomical tools."
+conda-forge = "pwkit"
+pypi = "pwkit"
+
+
+[[package]]
+description = "Python utilities for Cytoscape and Cytoscape.js"
+conda-forge = "py2cytoscape"
+pypi = "py2cytoscape"
+
+
+[[package]]
+description = "Python client library and toolkit for Neo4j"
+conda-forge = "py2neo"
+pypi = "py2neo"
+
+
+[[package]]
+description = "Enables Python programs to dynamically access arbitrary Java objects"
+conda-forge = "py4j"
+pypi = "py4j"
+
+
+[[package]]
+description = "A Python interface to the 6S Radiative Transfer Model"
+conda-forge = "py6s"
+pypi = "Py6S"
+
+
+[[package]]
+description = "A Python package for forward and inverse Abel transforms"
+conda-forge = "pyabel"
+pypi = "PyAbel"
+
+
+[[package]]
+description = "Python module (C extension and plain python) implementing Aho-Corasick algorithm."
+conda-forge = "pyahocorasick"
+pypi = "pyahocorasick"
+
+
+[[package]]
+description = "Python module to interface to the Alveo repository of speech and language data"
+conda-forge = "pyalveo"
+pypi = "pyalveo"
+
+
+[[package]]
+description = "Algebraic Multigrid Solvers in Python"
+conda-forge = "pyamg"
+pypi = "pyamg"
+
+
+[[package]]
+description = "PyYAML-based module to produce pretty and readable YAML-serialized data"
+conda-forge = "pyaml"
+pypi = "pyaml"
+
+
+[[package]]
+description = "Python module for working with ASDF files."
+conda-forge = "pyasdf"
+pypi = "pyasdf"
+
+
+[[package]]
+description = "A collection of ASN.1-based protocols modules."
+conda-forge = "pyasn1-modules"
+pypi = "pyasn1-modules"
+
+
+[[package]]
+description = "ASN.1 types and codecs"
+conda-forge = "pyasn1"
+pypi = "pyasn1"
+
+
+[[package]]
+description = "PortAudio Python Bindings."
+conda-forge = "pyaudio"
+pypi = "PyAudio"
+
+
+[[package]]
+description = "A cross-platform module for GUI automation for human beings. Control the keyboard and mouse from a Python script."
+conda-forge = "pyautogui"
+pypi = "PyAutoGUI"
+
+
+[[package]]
+description = "A framework for accessing bash completions from Python"
+conda-forge = "py-bash-completion"
+pypi = "bash_completion"
+
+
+[[package]]
+description = "Package for numerical tight-binding calculations in solid state physics"
+conda-forge = "pybinding"
+pypi = "pybinding"
+
+
+[[package]]
+description = "pyblake2 is an extension module for Python implementing BLAKE2 hash function.\nBLAKE2 is a cryptographic hash function, which offers highest security while being as fast as MD5 or SHA-1,\n"
+conda-forge = "pyblake2"
+pypi = "pyblake2"
+
+
+[[package]]
+description = "A docutils backend for pybtex."
+conda-forge = "pybtex-docutils"
+pypi = "pybtex-docutils"
+
+
+[[package]]
+description = "A BibTeX-compatible bibliography processor in Python"
+conda-forge = "pybtex"
+pypi = "pybtex"
+
+
+[[package]]
+description = "Python interface around the ECMWF-BUFR library."
+conda-forge = "pybufr-ecmwf"
+pypi = "pybufr-ecmwf"
+
+
+[[package]]
+description = "CALPHAD tools for designing thermodynamic models, calculating phase diagrams and investigating phase equilibria."
+conda-forge = "pycalphad"
+pypi = "pycalphad"
+
+
+[[package]]
+description = "Jupyter interface for Candela visualization components"
+conda-forge = "pycandela"
+pypi = "pycandela"
+
+
+[[package]]
+description = "A python wrapping of the C++ implementation of the Cap'n Proto library"
+conda-forge = "pycapnp"
+pypi = "pycapnp"
+
+
+[[package]]
+description = "Python library to interact with the Chef server API"
+conda-forge = "pychef"
+pypi = "PyChef"
+
+
+[[package]]
+description = "CIF file support for Python"
+conda-forge = "pycifrw"
+pypi = "PyCifRW"
+
+
+[[package]]
+description = "Python toolkit for characterizing Coal and Open-pit surface mining impacts on American Lands"
+conda-forge = "pycoal"
+pypi = "pycoal"
+
+
+[[package]]
+description = "Writing of coastlines, borders and rivers to images in Python"
+conda-forge = "pycoast"
+pypi = "pycoast"
+
+
+[[package]]
+description = "Python style guide checker"
+conda-forge = "pycodestyle"
+pypi = "pycodestyle"
+
+
+[[package]]
+description = "Python utility for HTCondor"
+conda-forge = "pycondor"
+pypi = "PyCondor"
+
+
+[[package]]
+description = "Create CovJSON files from common scientific data formats"
+conda-forge = "pycovjson"
+pypi = "pycovjson"
+
+
+[[package]]
+description = "Complete C99 parser in pure Python"
+conda-forge = "pycparser"
+pypi = "pycparser"
+
+
+[[package]]
+description = "A module for getting CPU info with Python 2 & 3"
+conda-forge = "py-cpuinfo"
+pypi = "py-cpuinfo"
+
+
+[[package]]
+description = "Utilities for scientific analysis of nanoscale imaging data"
+conda-forge = "pycroscopy"
+pypi = "pyCroscopy"
+
+
+[[package]]
+description = "Cryptographic library for Python"
+conda-forge = "pycryptodomex"
+pypi = "pycryptodomex"
+
+
+[[package]]
+description = "Cryptographic modules for Python."
+conda-forge = "pycrypto"
+pypi = "pycrypto"
+
+
+[[package]]
+description = "OGC Catalogue Service for the Web (CSW) server implementation written in Python."
+conda-forge = "pycsw"
+pypi = "pycsw"
+
+
+[[package]]
+description = "python package common tasks for users (e.g. copy examples, fetch data, ...)"
+conda-forge = "pyct"
+pypi = "pyct"
+
+
+[[package]]
+description = "A Python module for continuous wavelet spectral analysis"
+conda-forge = "pycwt"
+pypi = "pycwt"
+
+
+[[package]]
+description = "Pure Python Opendap/DODS client and server."
+conda-forge = "pydap"
+pypi = "Pydap"
+
+
+[[package]]
+description = "The kitchen sink of Python utility libraries for doing \"stuff\" in a functional way."
+conda-forge = "pydash"
+pypi = "pydash"
+
+
+[[package]]
+description = "Dempster-Shafer theory library"
+conda-forge = "py_dempster_shafer"
+pypi = "py_dempster_shafer"
+
+
+[[package]]
+description = "A python interface to Philipp Krähenbühl's fully-connected (dense) CRF code."
+conda-forge = "pydensecrf"
+pypi = "pydensecrf"
+
+
+[[package]]
+description = "Multi-producer-multi-consumer signal dispatching mechanism"
+conda-forge = "pydispatcher"
+pypi = "PyDispatcher"
+
+
+[[package]]
+description = "Python implementations of some functions from astronomical IDL libraries."
+conda-forge = "pydl"
+pypi = "pydl"
+
+
+[[package]]
+description = "Python docstring style checker (formerly pep257)"
+conda-forge = "pydocstyle"
+pypi = "pydocstyle"
+
+
+[[package]]
+description = "Design of experiments for Python"
+conda-forge = "pydoe"
+pypi = "pyDOE"
+
+
+[[package]]
+description = "Python interface to Graphviz's Dot language"
+conda-forge = "pydotplus"
+pypi = "pydotplus"
+
+
+[[package]]
+description = "Python interface to Graphviz's Dot"
+conda-forge = "pydot"
+pypi = "pydot"
+
+
+[[package]]
+description = "Google Drive API Python wrapper library"
+conda-forge = "pydrive"
+pypi = "PyDrive"
+
+
+[[package]]
+description = "A Python connector for Druid."
+conda-forge = "pydruid"
+pypi = "pydruid"
+
+
+[[package]]
+description = "Library for working with Disdrometer data, particle probes, and drop size distributions."
+conda-forge = "pydsd"
+pypi = "PyDSD"
+
+
+[[package]]
+description = "PyDSTool is a sophisticated & integrated simulation and analysis environment for dynamical systems models of physical systems (ODEs, DAEs, maps, and hybrid systems)."
+conda-forge = "pydstool"
+pypi = "PyDSTool"
+
+
+[[package]]
+description = "Python tool kit for multi-body dynamics."
+conda-forge = "pydy"
+pypi = "pydy"
+
+
+[[package]]
+description = "Library to read/write EDF+/BDF+ files based on EDFlib."
+conda-forge = "pyedflib"
+pypi = "pyEDFlib"
+
+
+[[package]]
+description = "Python wrapper for the Elastix nonrigid registration toolkit"
+conda-forge = "pyelastix"
+pypi = "9e118aa3f6684187e7ba3727864cfd8e8209ad2d4c59b668f1d41e76f241"
+
+
+[[package]]
+description = "Library for analyzing ELF files and DWARF debugging information"
+conda-forge = "pyelftools"
+pypi = "pyelftools"
+
+
+[[package]]
+description = "A Python wrapper for the Earth Mover's Distance."
+conda-forge = "pyemd"
+pypi = "pyemd"
+
+
+[[package]]
+description = "PyEMMA (EMMA = Emma's Markov Model Algorithms) is an open source Python/C package for analysis of extensive molecular dynamics simulations"
+conda-forge = "pyemma"
+pypi = "pyEMMA"
+
+
+[[package]]
+description = "Substitutes emoji aliases to emoji raw characters. Simple but sweet :smile:"
+conda-forge = "pyemojify"
+pypi = "pyemojify"
+
+
+[[package]]
+description = "Compute positions of the planets and stars"
+conda-forge = "pyephem"
+pypi = "pyephem"
+
+
+[[package]]
+description = "A Python package to create/manipulate OpenDocumentFormat files"
+conda-forge = "pyexcel-ezodf"
+pypi = "pyexcel-ezodf"
+
+
+[[package]]
+description = "One interface to read and write the data in various excel formats, import the data into and export the data from databases"
+conda-forge = "pyexcel-io"
+pypi = "pyexcel-io"
+
+
+[[package]]
+description = "A wrapper library to read, manipulate and write data in xls using xlrd and xlwt"
+conda-forge = "pyexcel-ods3"
+pypi = "pyexcel-ods3"
+
+
+[[package]]
+description = "Single API for reading, manipulating and writing data in csv, ods, xls, xlsx and xlsm files"
+conda-forge = "pyexcel"
+pypi = "pyexcel"
+
+
+[[package]]
+description = "A generic request and response interface for pyexcel web extensions."
+conda-forge = "pyexcel-webio"
+pypi = "pyexcel-webio"
+
+
+[[package]]
+description = "A wrapper library to read, manipulate and write data in xls using xlrd and xlwt"
+conda-forge = "pyexcel-xls"
+pypi = "pyexcel-xls"
+
+
+[[package]]
+description = "A wrapper library to read, manipulate and write data in xlsx and xlsm format using openpyxl"
+conda-forge = "pyexcel-xlsx"
+pypi = "pyexcel-xlsx"
+
+
+[[package]]
+description = "Create Exodus files with Python"
+conda-forge = "pyexodus"
+pypi = "pyexodus"
+
+
+[[package]]
+description = "pyface - traits-capable windowing framework"
+conda-forge = "pyface"
+pypi = "pyface"
+
+
+[[package]]
+description = "A pythonic wrapper around FFTW, the FFT library, presenting a unified interface for all the supported transforms."
+conda-forge = "pyfftw"
+pypi = "pyFFTW"
+
+
+[[package]]
+description = "Pure-python FIGlet implementation"
+conda-forge = "pyfiglet"
+pypi = "pyfiglet"
+
+
+[[package]]
+description = "A pure Python HDF5 file reader"
+conda-forge = "pyfive"
+pypi = "pyfive"
+
+
+[[package]]
+description = "Pyflakes analyzes programs and detects various errors."
+conda-forge = "pyflakes"
+pypi = "pyflakes"
+
+
+[[package]]
+description = "PyFMI is a package for loading and interacting with Functional Mock-Up Units"
+conda-forge = "pyfmi"
+pypi = "PyFMI"
+
+
+[[package]]
+description = "Python wrappers for FMMLIB2D and FMMLIB3D"
+conda-forge = "pyfmmlib"
+pypi = "pyfmmlib"
+
+
+[[package]]
+description = "pyfolio is a Python library for performance and risk analysis of financial portfolios"
+conda-forge = "pyfolio"
+pypi = "pyfolio"
+
+
+[[package]]
+description = "A Python implementation of the Frequent Pattern Growth algorithm."
+conda-forge = "pyfpgrowth"
+pypi = "pyfpgrowth"
+
+
+[[package]]
+description = "Generalized Additive Models in Python"
+conda-forge = "pygam"
+pypi = "pygam"
+
+
+[[package]]
+description = "Base class definition for I/O interfaces of poets°"
+conda-forge = "pygeobase"
+pypi = "pygeobase"
+
+
+[[package]]
+description = "Creation and handling of Discrete Global Grids or Point collections."
+conda-forge = "pygeogrids"
+pypi = "pygeogrids"
+
+
+[[package]]
+description = "A basic implementation of the __geo_interface__"
+conda-forge = "pygeoif"
+pypi = "pygeoif"
+
+
+[[package]]
+description = "Pure Python GeoIP API"
+conda-forge = "pygeoip"
+pypi = "pygeoip"
+
+
+[[package]]
+description = "pygeometa is a Python package to generate metadata for geospatial datasets"
+conda-forge = "pygeometa"
+pypi = "pygeometa"
+
+
+[[package]]
+description = "Python bindings for libgit2."
+conda-forge = "pygit2"
+pypi = "pygit2"
+
+
+[[package]]
+description = "Python library implementing the GitHub API v3"
+conda-forge = "pygithub"
+pypi = "PyGithub"
+
+
+[[package]]
+description = "Cross-platform windowing and multimedia library"
+conda-forge = "pyglet"
+pypi = "pyglet"
+
+
+[[package]]
+description = "Pygments lexer and style for the AnyScript language"
+conda-forge = "pygments_anyscript"
+pypi = "pygments_anyscript"
+
+
+[[package]]
+description = "Pygments is a generic syntax highlighter suitable for use in code hosting, forums, wikis or other applications that need to prettify source code."
+conda-forge = "pygments"
+pypi = "Pygments"
+
+
+[[package]]
+description = "ETL programming in Python"
+conda-forge = "pygrametl"
+pypi = "pygrametl"
+
+
+[[package]]
+description = "Small library to parse GraphML files in Python"
+conda-forge = "pygraphml"
+pypi = "pygraphml"
+
+
+[[package]]
+description = "Python interface to Graphviz"
+conda-forge = "pygraphviz"
+pypi = "pygraphviz"
+
+
+[[package]]
+description = "Python GRIB (editions 1 and 2) reader."
+conda-forge = "pygrib"
+pypi = "pygrib"
+
+
+[[package]]
+description = "Graph Signal Processing in Python"
+conda-forge = "pygsp"
+pypi = "PyGSP"
+
+
+[[package]]
+description = "Hamcrest framework for matcher objects"
+conda-forge = "pyhamcrest"
+pypi = "PyHamcrest"
+
+
+[[package]]
+description = "Hybrid Monte Carlo for Python"
+conda-forge = "pyhmc"
+pypi = "pyhmc"
+
+
+[[package]]
+description = "HOCON parser for Python"
+conda-forge = "pyhocon"
+pypi = "pyhocon"
+
+
+[[package]]
+description = "Welcome to PyICU, a Python extension wrapping the ICU C++ libraries."
+conda-forge = "pyicu"
+pypi = "PyICU"
+
+
+[[package]]
+description = "Monitoring filesystems events with inotify on Linux. http://github.com/seb-m/pyinotify/wiki"
+conda-forge = "pyinotify"
+pypi = "pyinotify"
+
+
+[[package]]
+description = "PyInstaller bundles a Python application and all its dependencies into a single package."
+conda-forge = "pyinstaller"
+pypi = "PyInstaller"
+
+
+[[package]]
+description = "A CPython extension supporting pyinstrument"
+conda-forge = "pyinstrument_cext"
+pypi = "pyinstrument_cext"
+
+
+[[package]]
+description = "A call stack profiler for Python. Inspired by Apple's Instruments.app"
+conda-forge = "pyinstrument"
+pypi = "pyinstrument"
+
+
+[[package]]
+description = "Atomistics plugin for pyiron - an integrated development environment (IDE) for computational materials science."
+conda-forge = "pyiron_atomistics"
+pypi = "pyiron_atomistics"
+
+
+[[package]]
+description = "Core module for pyiron - an integrated development environment (IDE) for computational materials science."
+conda-forge = "pyiron_base"
+pypi = "pyiron_base"
+
+
+[[package]]
+description = "Density functional theory (DFT) plugin for pyiron - an integrated development environment (IDE) for computational materials science."
+conda-forge = "pyiron_dft"
+pypi = "pyiron_dft"
+
+
+[[package]]
+description = "Example job class for pyiron - an integrated development environment (IDE) for computational materials science."
+conda-forge = "pyiron_example_job"
+pypi = "pyiron_example_job"
+
+
+[[package]]
+description = "Lammps plugin for pyiron - an integrated development environment (IDE) for computational materials science."
+conda-forge = "pyiron_lammps"
+pypi = "pyiron_lammps"
+
+
+[[package]]
+description = "pyiron - an integrated development environment (IDE) for computational materials science."
+conda-forge = "pyiron"
+pypi = "pyiron"
+
+
+[[package]]
+description = "Vasp plugin for pyiron - an integrated development environment (IDE) for computational materials science."
+conda-forge = "pyiron_vasp"
+pypi = "pyiron_vasp"
+
+
+[[package]]
+description = "Python implementation of the R package janitor."
+conda-forge = "pyjanitor"
+pypi = "pyjanitor"
+
+
+[[package]]
+description = "JSON Web Token implementation in Python"
+conda-forge = "pyjwt"
+pypi = "PyJWT"
+
+
+[[package]]
+description = "Apache Kafka client for Python; high-level & low-level consumer/producer, with great performance"
+conda-forge = "pykafka"
+pypi = "pykafka"
+
+
+[[package]]
+description = "An implementation of the Kalman Filter, Kalman Smoother, and EM algorithm in Python"
+conda-forge = "pykalman"
+pypi = "pykalman"
+
+
+[[package]]
+description = "Fast kd-tree implementation with OpenMP-enabled queries."
+conda-forge = "pykdtree"
+pypi = "pykdtree"
+
+
+[[package]]
+description = "Kriging Toolkit for Python"
+conda-forge = "pykrige"
+pypi = "PyKrige"
+
+
+[[package]]
+description = "Python lib/cli for JSON/YAML schema validation"
+conda-forge = "pykwalify"
+pypi = "pykwalify"
+
+
+[[package]]
+description = "Code audit tool for Python and JavaScript."
+conda-forge = "pylama"
+pypi = "pylama"
+
+
+[[package]]
+description = "Python library for interactive topic model visualization"
+conda-forge = "pyldavis"
+pypi = "pyLDAvis"
+
+
+[[package]]
+description = "Python implementation of the JSON-LD API"
+conda-forge = "pyld"
+pypi = "PyLD"
+
+
+[[package]]
+description = "A Python library for working with the Low Entropy Model Specification language (LEMS)"
+conda-forge = "pylems"
+pypi = "PyLEMS"
+
+
+[[package]]
+description = "A pure Python Levenshtein implementation that's not freaking GPL'd."
+conda-forge = "pylev"
+pypi = "pylev"
+
+
+[[package]]
+description = "Quick and small memcached client for Python"
+conda-forge = "pylibmc"
+pypi = "pylibmc"
+
+
+[[package]]
+description = "Scrypt for Python"
+conda-forge = "pylibscrypt"
+pypi = "pylibscrypt"
+
+
+[[package]]
+description = "pylint-celery is a Pylint plugin to aid Pylint in recognising and understandingerrors caused when using the Celery library"
+conda-forge = "pylint-celery"
+pypi = "pylint-celery"
+
+
+[[package]]
+description = "pylint-common is a Pylint plugin to improve Pylint error analysis of the standard Python library"
+conda-forge = "pylint-common"
+pypi = "pylint-common"
+
+
+[[package]]
+description = "A Pylint plugin to help Pylint understand the Django web framework"
+conda-forge = "pylint-django"
+pypi = "pylint-django"
+
+
+[[package]]
+description = "pylint-flask is a Pylint plugin to aid Pylint in recognizing and understanding errors caused when using Flask"
+conda-forge = "pylint-flask"
+pypi = "pylint-flask"
+
+
+[[package]]
+description = "Utilities and helpers for writing Pylint plugins"
+conda-forge = "pylint-plugin-utils"
+pypi = "pylint-plugin-utils"
+
+
+[[package]]
+description = "python code static checker"
+conda-forge = "pylint"
+pypi = "pylint"
+
+
+[[package]]
+description = "A Python package for estimating conditional logit models"
+conda-forge = "pylogit"
+pypi = "pylogit"
+
+
+[[package]]
+description = "LZ4Frame library for Python (via C bindings)"
+conda-forge = "py-lz4framed"
+pypi = "py-lz4framed"
+
+
+[[package]]
+description = "A python DB API 2 compatible client for mapd."
+conda-forge = "pymapd"
+pypi = "pymapd"
+
+
+[[package]]
+description = "A package for symbolic computation"
+conda-forge = "pymbolic"
+pypi = "pymbolic"
+
+
+[[package]]
+description = "Medical Physics python modules"
+conda-forge = "pymedphys"
+pypi = "pymedphys"
+
+
+[[package]]
+description = "The Materials Knowledge System in Python"
+conda-forge = "pymks"
+pypi = "pymks"
+
+
+[[package]]
+description = "A simple, cross-platform, pure Python module for JavaScript-like message boxes."
+conda-forge = "pymsgbox"
+pypi = "PyMsgBox"
+
+
+[[package]]
+description = "Pure Python MySQL Driver"
+conda-forge = "pymysql"
+pypi = "PyMySQL"
+
+
+[[package]]
+description = "Model, simulate, and visualize discrete nonlinear dynamical systems"
+conda-forge = "pynamical"
+pypi = "pynamical"
+
+
+[[package]]
+description = "A simple python library to apply NcML logic to NetCDF files."
+conda-forge = "pyncml"
+pypi = "pyncml"
+
+
+[[package]]
+description = "Pythonic bindings around the NFFT library"
+conda-forge = "pynfft"
+pypi = "pyNFFT"
+
+
+[[package]]
+description = "A thin, more convenient wrapper around MSNumpress"
+conda-forge = "pynumpress"
+pypi = "pynumpress"
+
+
+[[package]]
+description = "A Python API for working with Neurodata stored in the NWB Format"
+conda-forge = "pynwb"
+pypi = "pynwb"
+
+
+[[package]]
+description = "DB API Module for ODBC"
+conda-forge = "pyodbc"
+pypi = "pyodbc"
+
+
+[[package]]
+description = "Python wrapper around odeint (from the boost C++ library)"
+conda-forge = "pyodeint"
+pypi = "pyodeint"
+
+
+[[package]]
+description = "Pyomo: Python Optimization Modeling Objects"
+conda-forge = "pyomo"
+pypi = "Pyomo"
+
+
+[[package]]
+description = "Python wrapper for OpenCL"
+conda-forge = "pyopencl"
+pypi = "pyopencl"
+
+
+[[package]]
+description = "Standard OpenGL bindings for Python"
+conda-forge = "pyopengl"
+pypi = "PyOpenGL"
+
+
+[[package]]
+description = "Python wrapper module around the OpenSSL library"
+conda-forge = "pyopenssl"
+pypi = "pyOpenSSL"
+
+
+[[package]]
+description = "Orbital parameters and astronomical computations in Python"
+conda-forge = "pyorbital"
+pypi = "pyorbital"
+
+
+[[package]]
+description = "A python class for reading and writing orgmode files"
+conda-forge = "pyorgmode"
+pypi = "PyOrgMode"
+
+
+[[package]]
+description = "Thin wrapper for \"pandoc\""
+conda-forge = "pypandoc"
+pypi = "pypandoc"
+
+
+[[package]]
+description = "Create and execute simple grammars"
+conda-forge = "pyparsing"
+pypi = "pyparsing"
+
+
+[[package]]
+description = "A utility to read and write PDFs with Python"
+conda-forge = "pypdf2"
+pypi = "PyPDF2"
+
+
+[[package]]
+description = "A PEG Parser-Interpreter in Python"
+conda-forge = "pypeg2"
+pypi = "pyPEG2"
+
+
+[[package]]
+description = "A cross-platform clipboard module for Python. (only handles plain text for now)"
+conda-forge = "pyperclip"
+pypi = "pyperclip"
+
+
+[[package]]
+description = "Pure Python module to hyphenate text"
+conda-forge = "pyphen"
+pypi = "Pyphen"
+
+
+[[package]]
+description = "A progress bar and a percentage indicator object that let you track the progress of an iterative computation"
+conda-forge = "pyprind"
+pypi = "PyPrind"
+
+
+[[package]]
+description = "A python tool for Polymer Reference Interactions Site Model (PRISM) calculations"
+conda-forge = "pyprism"
+pypi = "pyPRISM"
+
+
+[[package]]
+description = "Scientific Graphics and GUI Library for Python"
+conda-forge = "pyqtgraph"
+pypi = "pyqtgraph"
+
+
+[[package]]
+description = "A jquery-like library for python"
+conda-forge = "pyquery"
+pypi = "pyquery"
+
+
+[[package]]
+description = "A Python library for quantum programming using Quil"
+conda-forge = "pyquil"
+pypi = "pyquil"
+
+
+[[package]]
+description = "library with cross-python path, ini-parsing, io, code, log facilities"
+conda-forge = "py"
+pypi = "py"
+
+
+[[package]]
+description = "Python parser for ds9 and ciao region files"
+conda-forge = "pyregion"
+pypi = "pyregion"
+
+
+[[package]]
+description = "A library for building flexible command line interfaces"
+conda-forge = "pyrepl"
+pypi = "pyrepl"
+
+
+[[package]]
+description = "Resampling of remote sensing data in Python."
+conda-forge = "pyresample"
+pypi = "pyresample"
+
+
+[[package]]
+description = "Python Rest Testing"
+conda-forge = "pyresttest"
+pypi = "pyresttest"
+
+
+[[package]]
+description = "PyRETIS: A well-done, medium-sized python library for rare events"
+conda-forge = "pyretis"
+pypi = "pyretis"
+
+
+[[package]]
+description = "Distributed object middleware for Python (RPC)"
+conda-forge = "pyro4"
+pypi = "Pyro4"
+
+
+[[package]]
+description = "Test your project's packaging friendliness"
+conda-forge = "pyroma"
+pypi = "pyroma"
+
+
+[[package]]
+description = "Library of spatial analysis functions."
+conda-forge = "pysal"
+pypi = "PySAL"
+
+
+[[package]]
+description = "Template tool for putting up the scaffold of a Python project."
+conda-forge = "pyscaffold"
+pypi = "pyscaffold"
+
+
+[[package]]
+description = "Python Monte Carlo Scenario Generator"
+conda-forge = "pyscenarios"
+pypi = "pyscenarios"
+
+
+[[package]]
+description = "Framework for webscraping."
+conda-forge = "pyscrap"
+pypi = "pyscrap"
+
+
+[[package]]
+description = "A simple, cross-platform screenshot module for Python 2 and 3."
+conda-forge = "pyscreeze"
+pypi = "PyScreeze"
+
+
+[[package]]
+description = "A wrapper around the SDL2 library"
+conda-forge = "pysdl2"
+pypi = "PySDL2"
+
+
+[[package]]
+description = "Python client to WeedFS"
+conda-forge = "pyseaweed"
+pypi = "pyseaweed"
+
+
+[[package]]
+description = "Python serial port access library"
+conda-forge = "pyserial"
+pypi = "pyserial"
+
+
+[[package]]
+description = "A friendly face on SFTP"
+conda-forge = "pysftp"
+pypi = "pysftp"
+
+
+[[package]]
+description = "Pure Python read/write support for ESRI Shapefile format."
+conda-forge = "pyshp"
+pypi = "pyshp"
+
+
+[[package]]
+description = "Python bindings for Qt"
+conda-forge = "pyside"
+pypi = "PySide"
+
+
+[[package]]
+description = "A convenient smbclient wrapper"
+conda-forge = "pysmbclient"
+pypi = "PySmbClient"
+
+
+[[package]]
+description = "SNMP SMI/MIB Parser"
+conda-forge = "pysmi"
+pypi = "pysmi"
+
+
+[[package]]
+description = "SNMP library for Python"
+conda-forge = "pysnmp"
+pypi = "pysnmp"
+
+
+[[package]]
+description = "A Python SOCKS client module. See https://github.com/Anorov/PySocks for more information."
+conda-forge = "pysocks"
+pypi = "PySocks"
+
+
+[[package]]
+description = "Lightweight python wrapper for Apache Solr."
+conda-forge = "pysolr"
+pypi = "pysolr"
+
+
+[[package]]
+description = "Surrogate Optimization Toolbox"
+conda-forge = "pysot"
+pypi = "pySOT"
+
+
+[[package]]
+description = "SoundFile is an audio library based on libsndfile, CFFI, and NumPy"
+conda-forge = "pysoundfile"
+pypi = "SoundFile"
+
+
+[[package]]
+description = "Reading and manipulaing satellite sensor spectral responses and the solar spectrum, to perfom various corrections to VIS and NIR band data"
+conda-forge = "pyspectral"
+pypi = "pyspectral"
+
+
+[[package]]
+description = "Mustache for Python"
+conda-forge = "pystache"
+pypi = "pystache"
+
+
+[[package]]
+description = "Python interface to Stan, a package for Bayesian inference"
+conda-forge = "pystan"
+pypi = "pystan"
+
+
+[[package]]
+description = "Python library for string matching."
+conda-forge = "py_stringmatching"
+pypi = "py_stringmatching"
+
+
+[[package]]
+description = "Cortical surface visualization using Python"
+conda-forge = "pysurfer"
+pypi = "pysurfer"
+
+
+[[package]]
+description = "Python 3 portage of pysvg"
+conda-forge = "pysvg-py3"
+pypi = "pysvg-py3"
+
+
+[[package]]
+description = "pytest plugin to help with comparing array output from tests"
+conda-forge = "pytest-arraydiff"
+pypi = "pytest-arraydiff"
+
+
+[[package]]
+description = "A plugin for pytest devs to view how assertion rewriting recodes the AST"
+conda-forge = "pytest-ast-back-to-python"
+pypi = "pytest-ast-back-to-python"
+
+
+[[package]]
+description = "Meta-package containing dependencies for testing Astropy"
+conda-forge = "pytest-astropy"
+pypi = "pytest-astropy"
+
+
+[[package]]
+description = "Pytest support for asyncio"
+conda-forge = "pytest-asyncio"
+pypi = "pytest-asyncio"
+
+
+[[package]]
+description = "pytest plugin for URL based testing"
+conda-forge = "pytest-base-url"
+pypi = "pytest-base-url"
+
+
+[[package]]
+description = "A py.test fixture for benchmarking code"
+conda-forge = "pytest-benchmark"
+pypi = "pytest-benchmark"
+
+
+[[package]]
+description = "pytest plugin with mechanisms for caching across test runs"
+conda-forge = "pytest-cache"
+pypi = "pytest-cache"
+
+
+[[package]]
+description = "py.test plugin to catch log messages. This is a fork of pytest-capturelog."
+conda-forge = "pytest-catchlog"
+pypi = "pytest-catchlog"
+
+
+[[package]]
+description = "Pytest plugin for testing console scripts"
+conda-forge = "pytest-console-scripts"
+pypi = "pytest-console-scripts"
+
+
+[[package]]
+description = "A Pytest plugin for your Cookiecutter templates"
+conda-forge = "pytest-cookies"
+pypi = "pytest-cookies"
+
+
+[[package]]
+description = "Pytest plugin for measuring coverage"
+conda-forge = "pytest-cov"
+pypi = "pytest-cov"
+
+
+[[package]]
+description = "Use pytest's runner to discover and execute C++ tests"
+conda-forge = "pytest-cpp"
+pypi = "pytest-cpp"
+
+
+[[package]]
+description = "pytest plugin for manipulating test data directories and files."
+conda-forge = "pytest-datadir"
+pypi = "pytest-datadir"
+
+
+[[package]]
+description = "django-haystack plugin for py.test"
+conda-forge = "pytest-django-haystack"
+pypi = "pytest-django-haystack"
+
+
+[[package]]
+description = "A Django plugin for py.test"
+conda-forge = "pytest-django"
+pypi = "pytest-django"
+
+
+[[package]]
+description = "Pytest plugin with advanced doctest features"
+conda-forge = "pytest-doctestplus"
+pypi = "pytest-doctestplus"
+
+
+[[package]]
+description = "py.test plugin that allows you to add environment variables."
+conda-forge = "pytest-env"
+pypi = "pytest-env"
+
+
+[[package]]
+description = "py.test plugin that activates the fault handler module for tests"
+conda-forge = "pytest-faulthandler"
+pypi = "pytest-faulthandler"
+
+
+[[package]]
+description = "pytest plugin to check FLAKE8 requirements"
+conda-forge = "pytest-flake8"
+pypi = "pytest-flake8"
+
+
+[[package]]
+description = "pytest plugin to check source code with pyflakes"
+conda-forge = "pytest-flakes"
+pypi = "pytest-flakes"
+
+
+[[package]]
+description = "A set of py.test fixtures to test Flask applications"
+conda-forge = "pytest-flask"
+pypi = "pytest-flask"
+
+
+[[package]]
+description = "run tests in isolated forked subprocesses"
+conda-forge = "pytest-forked"
+pypi = "pytest-forked"
+
+
+[[package]]
+description = "pytest plugin for generating HTML reports"
+conda-forge = "pytest-html"
+pypi = "pytest-html"
+
+
+[[package]]
+description = "ignore failures from flaky tests (pytest plugin)"
+conda-forge = "pytest-ignore-flaky"
+pypi = "pytest-ignore-flaky"
+
+
+[[package]]
+description = "Generate JSON test reports"
+conda-forge = "pytest-json"
+pypi = "pytest-json"
+
+
+[[package]]
+description = "It helps to use fixtures in pytest.mark.parametrize"
+conda-forge = "pytest-lazy-fixture"
+pypi = "pytest-lazy-fixture"
+
+
+[[package]]
+description = "pytest-localserver is a plugin for the pytest testing framework which enables you to test server connections locally."
+conda-forge = "pytest-localserver"
+pypi = "pytest-localserver"
+
+
+[[package]]
+description = "pytest plugin to run the mccabe code complexity checker."
+conda-forge = "pytest-mccabe"
+pypi = "pytest-mccabe"
+
+
+[[package]]
+description = "pytest plugin for test session metadata"
+conda-forge = "pytest-metadata"
+pypi = "pytest-metadata"
+
+
+[[package]]
+description = "Thin-wrapper around the mock package for easier use with py.test"
+conda-forge = "pytest-mock"
+pypi = "pytest-mock"
+
+
+[[package]]
+description = "pytest plugin to help with testing figures output from Matplotlib"
+conda-forge = "pytest-mpl"
+pypi = "pytest-mpl"
+
+
+[[package]]
+description = "Pytest plugin for detecting inadvertent open file handles"
+conda-forge = "pytest-openfiles"
+pypi = "pytest-openfiles"
+
+
+[[package]]
+description = "py.test plugin for efficiently checking PEP8 compliance"
+conda-forge = "pytest-pep8"
+pypi = "pytest-pep8"
+
+
+[[package]]
+description = "pytest plugin for running pylint against your codebase"
+conda-forge = "pytest-pylint"
+pypi = "pytest-pylint"
+
+
+[[package]]
+description = "pytest support for PyQt and PySide applications"
+conda-forge = "pytest-qt"
+pypi = "pytest-qt"
+
+
+[[package]]
+description = "Simple and powerful testing with Python."
+conda-forge = "pytest"
+pypi = "pytest"
+
+
+[[package]]
+description = "Pytest plugin for controlling remote data access"
+conda-forge = "pytest-remotedata"
+pypi = "pytest-remotedata"
+
+
+[[package]]
+description = "Saves shell scripts that allow re-execute previous pytest runs to reproduce crashes or flaky tests"
+conda-forge = "pytest-replay"
+pypi = "pytest-replay"
+
+
+[[package]]
+description = "Invoke py.test as distutils command with dependency resolution."
+conda-forge = "pytest-runner"
+pypi = "pytest-runner"
+
+
+[[package]]
+description = "pytest-selenium is a plugin for py.test that provides support for running Selenium based tests."
+conda-forge = "pytest-selenium"
+pypi = "pytest-selenium"
+
+
+[[package]]
+description = "Local SFTP server fixture plugin for pytest"
+conda-forge = "pytest-sftpserver"
+pypi = "pytest-sftpserver"
+
+
+[[package]]
+description = "Smart coverage measurement for py.test."
+conda-forge = "pytest-smartcov"
+pypi = "pytest-smartcov"
+
+
+[[package]]
+description = "a plugin for py.test that changes the default look and feel of py.test "
+conda-forge = "pytest-sugar"
+pypi = "pytest-sugar"
+
+
+[[package]]
+description = "When re-running a test suite, skip re-running of tests if code affecting those tests has not changed."
+conda-forge = "pytest-testmon"
+pypi = "pytest-testmon"
+
+
+[[package]]
+description = "This is a plugin which will terminate tests after a certain timeout."
+conda-forge = "pytest-timeout"
+pypi = "pytest-timeout"
+
+
+[[package]]
+description = "A py.test plugin providing fixtures and markers to simplify testing of\nasynchronous tornado applications.\n"
+conda-forge = "pytest-tornado"
+pypi = "pytest-tornado"
+
+
+[[package]]
+description = "pytest plugin for providing variables to tests/fixtures"
+conda-forge = "pytest-variables"
+pypi = "pytest-variables"
+
+
+[[package]]
+description = "Local continuous test runner with pytest and watchdog."
+conda-forge = "pytest-watch"
+pypi = "pytest-watch"
+
+
+[[package]]
+description = "py.test xdist plugin for distributed testing and loop-on-failing modes"
+conda-forge = "pytest-xdist"
+pypi = "pytest-xdist"
+
+
+[[package]]
+description = "OpenID support for modern servers and consumers."
+conda-forge = "python3-openid"
+pypi = "python3-openid"
+
+
+[[package]]
+description = "Approximate Nearest Neighbors in C++/Python optimized for memory usage and loading/saving to disk."
+conda-forge = "python-annoy"
+pypi = "annoy"
+
+
+[[package]]
+description = "Pure python implementation of the BiDi layout algorithm"
+conda-forge = "python-bidi"
+pypi = "python-bidi"
+
+
+[[package]]
+description = "A Python wrapper for the extremely fast Blosc compression library"
+conda-forge = "python-blosc"
+pypi = "blosc"
+
+
+[[package]]
+description = "Python dictionaries with recursive dot notation access"
+conda-forge = "python-box"
+pypi = "python-box"
+
+
+[[package]]
+description = "The can package provides controller area network support for Python developers "
+conda-forge = "python-can"
+pypi = "python-can"
+
+
+[[package]]
+description = "Use CDO in the context of Python as if it would be a native library."
+conda-forge = "python-cdo"
+pypi = "cdo"
+
+
+[[package]]
+description = "Confluent's Apache Kafka client for Python"
+conda-forge = "python-confluent-kafka"
+pypi = "confluent-kafka"
+
+
+[[package]]
+conda-forge = "python-constraint"
+pypi = "python-constraint"
+
+
+[[package]]
+description = "Python client library for Core API."
+conda-forge = "python-coreapi"
+pypi = "coreapi"
+
+
+[[package]]
+description = "Python interface to coreschema"
+conda-forge = "python-coreschema"
+pypi = "coreschema"
+
+
+[[package]]
+description = "Python library for working with CouchDB"
+conda-forge = "python-couchdb"
+pypi = "CouchDB"
+
+
+[[package]]
+description = "Python interface to coveralls.io API\\n"
+conda-forge = "python-coveralls"
+pypi = "python-coveralls"
+
+
+[[package]]
+description = "Python interface for the ESO Common Pipeline Library"
+conda-forge = "python-cpl"
+pypi = "python-cpl"
+
+
+[[package]]
+description = "Python binding for CRFsuite"
+conda-forge = "python-crfsuite"
+pypi = "python-crfsuite"
+
+
+[[package]]
+description = "Crontab module for reading and writing crontab files and accessing the system cron automatically and simply using a direct API."
+conda-forge = "python-crontab"
+pypi = "python-crontab"
+
+
+[[package]]
+description = "Extensions to the standard Python datetime module."
+conda-forge = "python-dateutil"
+pypi = "python-dateutil"
+
+
+[[package]]
+description = "Strict separation of config from code."
+conda-forge = "python-decouple"
+pypi = "python-decouple"
+
+
+[[package]]
+description = "Create and update Microsoft Word .docx files."
+conda-forge = "python-docx"
+pypi = "python-docx"
+
+
+[[package]]
+description = "Get and set values in your .env file in local and production servers like Heroku does."
+conda-forge = "python-dotenv"
+pypi = "python-dotenv"
+
+
+[[package]]
+description = "Programmatically open an editor, capture the result."
+conda-forge = "python-editor"
+pypi = "python-editor"
+
+
+[[package]]
+description = "Engine.IO server"
+conda-forge = "python-engineio"
+pypi = "python-engineio"
+
+
+[[package]]
+description = "Interpolation of geographic tiepoints in Python"
+conda-forge = "python-geotiepoints"
+pypi = "python-geotiepoints"
+
+
+[[package]]
+description = "A wrapper for the Gnu Privacy Guard (GPG or GnuPG)"
+conda-forge = "python-gnupg"
+pypi = "python-gnupg"
+
+
+[[package]]
+description = "Simple Python interface for Graphviz"
+conda-forge = "python-graphviz"
+pypi = "graphviz"
+
+
+[[package]]
+description = "HdfsCLI: API and command line interface for HDFS."
+conda-forge = "python-hdfs"
+pypi = "hdfs"
+
+
+[[package]]
+description = "Python Highcharts wrapper"
+conda-forge = "python-highcharts"
+pypi = "python-highcharts"
+
+
+[[package]]
+description = "The Python module hostlist.py knows how to expand and collect LLNL hostlists, as used by SLURM, pdsh, powerman, and genders, among other projects"
+conda-forge = "python-hostlist"
+pypi = "python-hostlist"
+
+
+[[package]]
+description = "SendGrid's Python HTTP Client for calling APIs"
+conda-forge = "python_http_client"
+pypi = "python_http_client"
+
+
+[[package]]
+description = "High performance graph data structures and algorithms"
+conda-forge = "python-igraph"
+pypi = "python-igraph"
+
+
+[[package]]
+description = "A python API for iRODS"
+conda-forge = "python-irodsclient"
+pypi = "python-irodsclient"
+
+
+[[package]]
+description = "Python Bindings to the OpenStack Ironic API"
+conda-forge = "python-ironicclient"
+pypi = "python-ironicclient"
+
+
+[[package]]
+description = "A python library adding a json log formatter"
+conda-forge = "python-json-logger"
+pypi = "python-json-logger"
+
+
+[[package]]
+description = "The official Kubernetes python client."
+conda-forge = "python-kubernetes"
+pypi = "kubernetes"
+
+
+[[package]]
+description = "Python bindings for leveldb database library"
+conda-forge = "python-leveldb"
+pypi = "leveldb"
+
+
+[[package]]
+description = "Python extension for computing string edit distances and similarities."
+conda-forge = "python-levenshtein"
+pypi = "python-levenshtein"
+
+
+[[package]]
+description = "Python interface to libarchive"
+conda-forge = "python-libarchive-c"
+pypi = "libarchive-c"
+
+
+[[package]]
+description = "Louvain Community Detection"
+conda-forge = "python-louvain"
+pypi = "python-louvain"
+
+
+[[package]]
+description = "Python bindings for the LZO data compression library"
+conda-forge = "python-lzo"
+pypi = "python-lzo"
+
+
+[[package]]
+description = "File type identification using libmagic"
+conda-forge = "python-magic"
+pypi = "python-magic"
+
+
+[[package]]
+description = "Static memory-efficient & fast Trie-like structures for Python (based on marisa-trie C++ library)"
+conda-forge = "python-marisa-trie"
+pypi = "marisa-trie"
+
+
+[[package]]
+description = "Math extension for Python-Markdown."
+conda-forge = "python-markdown-math"
+pypi = "python-markdown-math"
+
+
+[[package]]
+description = "Pure python memcached client"
+conda-forge = "python-memcached"
+pypi = "python-memcached"
+
+
+[[package]]
+description = "A module provides basic functions for parsing mime-type names and matching them against a list of media-ranges."
+conda-forge = "python-mimeparse"
+pypi = "python-mimeparse"
+
+
+[[package]]
+description = "A Python package for representing and reading electrophysiology data."
+conda-forge = "python-neo"
+pypi = "neo"
+
+
+[[package]]
+description = "port of node-semver"
+conda-forge = "python-node-semver"
+pypi = "node-semver"
+
+
+[[package]]
+description = "Python NVD3 - Chart Library for d3.js"
+conda-forge = "python-nvd3"
+pypi = "python-nvd3"
+
+
+[[package]]
+description = "OAuth 2.0 provider written in python"
+conda-forge = "python-oauth2"
+pypi = "python-oauth2"
+
+
+[[package]]
+description = "Cross-platform alternative to unix patch utility capable to apply unified diffs"
+conda-forge = "python-patch"
+pypi = "patch"
+
+
+[[package]]
+description = "Wkhtmltopdf python wrapper to convert html to pdf"
+conda-forge = "python-pdfkit"
+pypi = "pdfkit"
+
+
+[[package]]
+description = "A high level Python interface to the PKCS#11 (Cryptoki) standard to support HSM and Smartcard devices"
+conda-forge = "python-pkcs11"
+pypi = "python-pkcs11"
+
+
+[[package]]
+description = "Generate and manipulate Open XML PowerPoint (.pptx) files"
+conda-forge = "python-pptx"
+pypi = "python-pptx"
+
+
+[[package]]
+description = "Fast prime number generator. Python bindings for primesieve C/C++ library"
+conda-forge = "python-primesieve"
+pypi = "primesieve"
+
+
+[[package]]
+description = "Python wrapper around rapidjson"
+conda-forge = "python-rapidjson"
+pypi = "python-rapidjson"
+
+
+[[package]]
+description = "A Python Slugify application that handles Unicode"
+conda-forge = "python-slugify"
+pypi = "python-slugify"
+
+
+[[package]]
+description = "Python library for the snappy compression library from Google"
+conda-forge = "python-snappy"
+pypi = "python-snappy"
+
+
+[[package]]
+description = "Socket.IO server"
+conda-forge = "python-socketio"
+pypi = "python-socketio"
+
+
+[[package]]
+description = "Play and Record Sound with Python"
+conda-forge = "python-sounddevice"
+pypi = "sounddevice"
+
+
+[[package]]
+description = "A pure Python interface for the Telegram Bot API."
+conda-forge = "python-telegram-bot"
+pypi = "python-telegram-bot"
+
+
+[[package]]
+description = "Console colouring for python"
+conda-forge = "python-termstyle"
+pypi = "termstyle"
+
+
+[[package]]
+description = "Make ternary plots in matplotlib."
+conda-forge = "python-ternary"
+pypi = "python-ternary"
+
+
+[[package]]
+description = "Python Utils is a collection of small Python functions and classes which make common patterns shorter and easier."
+conda-forge = "python-utils"
+pypi = "python-utils"
+
+
+[[package]]
+description = "pure python download utility"
+conda-forge = "python-wget"
+pypi = "wget"
+
+
+[[package]]
+description = "Python binding for xxHash"
+conda-forge = "python-xxhash"
+pypi = "xxhash"
+
+
+[[package]]
+description = "a claimless python to c++ converter"
+conda-forge = "pythran"
+pypi = "pythran"
+
+
+[[package]]
+description = "A Python / ThreeJS bridge utilizing the Jupyter widget infrastructure."
+conda-forge = "pythreejs"
+pypi = "pythreejs"
+
+
+[[package]]
+description = "A small Python library to parse various kinds of time expressions"
+conda-forge = "pytimeparse"
+pypi = "pytimeparse"
+
+
+[[package]]
+description = "A Python code for computing the scattering properties of homogeneous nonspherical scatterers with the T-Matrix method."
+conda-forge = "pytmatrix"
+pypi = "pytmatrix"
+
+
+[[package]]
+description = "A TOML-0.4.0 parser/writer for Python."
+conda-forge = "pytoml"
+pypi = "pytoml"
+
+
+[[package]]
+description = "A collection of tools for Python"
+conda-forge = "pytools"
+pypi = "pytools"
+
+
+[[package]]
+description = "Import Trackmate XML files in Python as Pandas dataframe."
+conda-forge = "pytrackmate"
+pypi = "pytrackmate"
+
+
+[[package]]
+description = "A pure Python implementation of the trie data structure."
+conda-forge = "pytrie"
+pypi = "PyTrie"
+
+
+[[package]]
+description = "Ttk Python wrapper"
+conda-forge = "pyttk"
+pypi = "pyttk"
+
+
+[[package]]
+description = "A collection of tweening / easing functions"
+conda-forge = "pytweening"
+pypi = "PyTweening"
+
+
+[[package]]
+description = "Typing-toolbox for Python 3 _and_ 2.7 w.r.t. PEP 484."
+conda-forge = "pytypes"
+pypi = "pytypes"
+
+
+[[package]]
+description = "Official timezone database for Python"
+conda-forge = "pytzdata"
+pypi = "pytzdata"
+
+
+[[package]]
+description = "World timezone definitions, modern and historical."
+conda-forge = "pytz"
+pypi = "pytz"
+
+
+[[package]]
+description = "Universal Binary JSON draft-12 serializer for Python"
+conda-forge = "py-ubjson"
+pypi = "py-ubjson"
+
+
+[[package]]
+description = "a Python implementation of the Unicode Collation Algorithm"
+conda-forge = "pyuca"
+pypi = "pyuca"
+
+
+[[package]]
+description = "PyUnfold: A Python package for iterative unfolding"
+conda-forge = "pyunfold"
+pypi = "PyUnfold"
+
+
+[[package]]
+description = "Convex Optimization in Python using Proximal Splitting"
+conda-forge = "pyunlocbox"
+pypi = "pyunlocbox"
+
+
+[[package]]
+description = "PyUtilib: A collection of Python utilities"
+conda-forge = "pyutilib"
+pypi = "PyUtilib"
+
+
+[[package]]
+description = "A collection of convenience functions"
+conda-forge = "pyutilsnrw"
+pypi = "pyutilsnrw"
+
+
+[[package]]
+description = "pyuv is a Python module which provides an interface to libuv."
+conda-forge = "pyuv"
+pypi = "pyuv"
+
+
+[[package]]
+description = "Python VISA bindings for GPIB, RS232, and USB instruments"
+conda-forge = "pyvisa-py"
+pypi = "PyVISA-py"
+
+
+[[package]]
+description = "Control your instruments with Python."
+conda-forge = "pyvisa"
+pypi = "pyvisa"
+
+
+[[package]]
+description = "Large-scale Visualization Data Storage"
+conda-forge = "pyvisfile"
+pypi = "pyvisfile"
+
+
+[[package]]
+description = "Bidirectional communication for PyViz"
+conda-forge = "pyviz_comms"
+pypi = "pyviz_comms"
+
+
+[[package]]
+description = "Astropy affiliated package for accessing Virtual Observatory data and services"
+conda-forge = "pyvo"
+pypi = "pyvo"
+
+
+[[package]]
+description = "PyVTK tools for manipulating Visualization Toolkit (VTK) files in Python"
+conda-forge = "pyvtk"
+pypi = "PyVTK"
+
+
+[[package]]
+description = "Python wrapper for the hadoop WebHDFS Rest API"
+conda-forge = "pywebhdfs"
+pypi = "pywebhdfs"
+
+
+[[package]]
+description = "PyWEED: A cross-platform app for retrieving event-based seismic data."
+conda-forge = "pyweed"
+pypi = "pyweed"
+
+
+[[package]]
+description = "https://github.com/OpenWIM/pywim"
+conda-forge = "pywim"
+pypi = "pywim"
+
+
+[[package]]
+description = "Python library for Windows Remote Management (WinRM)"
+conda-forge = "pywinrm"
+pypi = "pywinrm"
+
+
+[[package]]
+description = "High performance Damerau-Levenshtein (DL) edit distance algorithm for Python."
+conda-forge = "pyxdameraulevenshtein"
+pypi = "pyxDamerauLevenshtein"
+
+
+[[package]]
+description = "Python tools for building Flask-based web applications"
+conda-forge = "pyxley"
+pypi = "pyxley"
+
+
+[[package]]
+description = "YAML parser and emitter for Python"
+conda-forge = "pyyaml"
+pypi = "PyYAML"
+
+
+[[package]]
+description = "Python bindings for zeromq"
+conda-forge = "pyzmq"
+pypi = "pyzmq"
+
+
+[[package]]
+description = "Python SDK for coding to the Qubole Data Service API"
+conda-forge = "qds-sdk"
+pypi = "qds-sdk"
+
+
+[[package]]
+description = "Pandas DataFrame viewer for Jupyter Notebook"
+conda-forge = "qgrid"
+pypi = "qgrid"
+
+
+[[package]]
+description = "Conversion between QImages and numpy.ndarrays."
+conda-forge = "qimage2ndarray"
+pypi = "qimage2ndarray"
+
+
+[[package]]
+description = "QR Code image generator."
+conda-forge = "qrcode"
+pypi = "qrcode"
+
+
+[[package]]
+description = "Iconic fonts in PyQt and PySide applications"
+conda-forge = "qtawesome"
+pypi = "qtawesome"
+
+
+[[package]]
+description = "QtBinder thinly wraps Qt widgets with Traits"
+conda-forge = "qt_binder"
+pypi = "qt_binder"
+
+
+[[package]]
+description = "Jupyter Qt console"
+conda-forge = "qtconsole"
+pypi = "qtconsole"
+
+
+[[package]]
+description = "Minimal Python 2 & 3 shim around all Qt bindings - PySide, PySide2, PyQt4 and PyQt5."
+conda-forge = "qt.py"
+pypi = "Qt.py"
+
+
+[[package]]
+description = "A uniform layer to support PyQt5, PyQt4 and PySide with a single codebase"
+conda-forge = "qtpy"
+pypi = "qtpy"
+
+
+[[package]]
+description = "A inspector widget to view and modify style sheet of a Qt app in runtime."
+conda-forge = "qt_style_sheet_inspector"
+pypi = "qt_style_sheet_inspector"
+
+
+[[package]]
+description = "Source for financial, economic, and alternative datasets."
+conda-forge = "quandl"
+pypi = "Quandl"
+
+
+[[package]]
+description = "Physical quantities with units, based upon numpy."
+conda-forge = "quantities"
+pypi = "quantities"
+
+
+[[package]]
+description = "A Launcher for QuantLab based applications."
+conda-forge = "quantlab_launcher"
+pypi = "quantlab_launcher"
+
+
+[[package]]
+description = "A pre-alpha version of a computational environment for quant"
+conda-forge = "quantlab"
+pypi = "quantlab"
+
+
+[[package]]
+description = "Add built-in support for quaternions to numpy"
+conda-forge = "quaternion"
+pypi = "numpy-quaternion"
+
+
+[[package]]
+description = "Tools for Beam I/O and Manipulation"
+conda-forge = "radio-beam"
+pypi = "radio_beam"
+
+
+[[package]]
+description = "Provide support for radio-spectra to sunpy"
+conda-forge = "radiospectra"
+pypi = "radiospectra"
+
+
+[[package]]
+description = "Code Metrics in Python"
+conda-forge = "radon"
+pypi = "radon"
+
+
+[[package]]
+description = "RAKE short for Rapid Automatic Keyword Extraction algorithm"
+conda-forge = "rake_nltk"
+pypi = "rake_nltk"
+
+
+[[package]]
+description = "A port of David Merfield's randomColor to python."
+conda-forge = "randomcolor"
+pypi = "randomcolor"
+
+
+[[package]]
+description = "A simple python module containing an in-place linear rank filter optimized in C++."
+conda-forge = "rank_filter"
+pypi = "rank_filter"
+
+
+[[package]]
+description = "A python interface for the RAPID program (rapid-hub.org)."
+conda-forge = "rapidpy"
+pypi = "RAPIDpy"
+
+
+[[package]]
+description = "Rasterio reads and writes geospatial raster datasets."
+conda-forge = "rasterio"
+pypi = "rasterio"
+
+
+[[package]]
+description = "Summarize geospatial raster datasets based on vector geometries."
+conda-forge = "rasterstats"
+pypi = "rasterstats"
+
+
+[[package]]
+description = "Simple Python module providing rate limiting."
+conda-forge = "ratelimiter"
+pypi = "ratelimiter"
+
+
+[[package]]
+description = "Makes it easy to respect rate limits."
+conda-forge = "ratelim"
+pypi = "ratelim"
+
+
+[[package]]
+description = "A Python library for OAuth 1.0/a, 2.0, and Ofly."
+conda-forge = "rauth"
+pypi = "rauth"
+
+
+[[package]]
+description = "An aiohttp transport for raven-python"
+conda-forge = "raven-aiohttp"
+pypi = "raven-aiohttp"
+
+
+[[package]]
+description = "Raven is a client for Sentry (https://getsentry.com)"
+conda-forge = "raven"
+pypi = "raven"
+
+
+[[package]]
+description = "Fast CSS minifier for Python"
+conda-forge = "rcssmin"
+pypi = "rcssmin"
+
+
+[[package]]
+description = "RDFLib is a Python library for working with RDF, a simple yet powerful language for representing information."
+conda-forge = "rdflib"
+pypi = "rdflib"
+
+
+[[package]]
+description = "Read ROI files .zip or .roi generated with ImageJ."
+conda-forge = "read-roi"
+pypi = "read-roi"
+
+
+[[package]]
+description = "An open-source multi-purpose N-body code"
+conda-forge = "rebound"
+pypi = "rebound"
+
+
+[[package]]
+description = "A docutils-compatibility bridge to CommonMark."
+conda-forge = "recommonmark"
+pypi = "recommonmark"
+
+
+[[package]]
+description = "SQL for Humans"
+conda-forge = "records"
+pypi = "records"
+
+
+[[package]]
+description = "coloured output for nosetests"
+conda-forge = "rednose"
+pypi = "rednose"
+
+
+[[package]]
+description = "Jupyter widget-based package for reducing FITS images"
+conda-forge = "reducer"
+pypi = "reducer"
+
+
+[[package]]
+description = "Alternative regular expression module, to replace re."
+conda-forge = "regex"
+pypi = "regex"
+
+
+[[package]]
+description = "plotting and creation of masks of spatial regions"
+conda-forge = "regionmask"
+pypi = "regionmask"
+
+
+[[package]]
+description = "Astropy affilated package for region handling"
+conda-forge = "regions"
+pypi = "regions"
+
+
+[[package]]
+description = "Clever dispatch"
+conda-forge = "reg"
+pypi = "reg"
+
+
+[[package]]
+description = "GPGPU algorithms for PyCUDA and PyOpenCL"
+conda-forge = "reikna"
+pypi = "reikna"
+
+
+[[package]]
+description = "An AMQP (RabbitMQ) consumer daemon and message processing framework"
+conda-forge = "rejected"
+pypi = "rejected"
+
+
+[[package]]
+description = "A quick unittest-compatible framework for repeating a test function over many fixtures"
+conda-forge = "repeated_test"
+pypi = "repeated_test"
+
+
+[[package]]
+description = "Open-source engine for creating complex, data-driven PDF documents and custom vector graphics"
+conda-forge = "reportlab"
+pypi = "reportlab"
+
+
+[[package]]
+description = "Quickly create HTML reports using a set of JINJA templates"
+conda-forge = "reports"
+pypi = "reports"
+
+
+[[package]]
+description = "The reproject package implements image reprojection (resampling) methods for astronomical data."
+conda-forge = "reproject"
+pypi = "reproject"
+
+
+[[package]]
+description = "Linux tool enabling reproducible experiments (docker plugin)"
+conda-forge = "reprounzip-docker"
+pypi = "reprounzip-docker"
+
+
+[[package]]
+description = "Graphical user interface for reprounzip, using Qt"
+conda-forge = "reprounzip-qt"
+pypi = "reprounzip-qt"
+
+
+[[package]]
+description = "Linux tool enabling reproducible experiments (unpacker)"
+conda-forge = "reprounzip"
+pypi = "reprounzip"
+
+
+[[package]]
+description = "Linux tool enabling reproducible experiments (vagrant plugin)"
+conda-forge = "reprounzip-vagrant"
+pypi = "reprounzip-vagrant"
+
+
+[[package]]
+description = "Jupyter Notebook tracing/reproduction using ReproZip"
+conda-forge = "reprozip-jupyter"
+pypi = "reprozip-jupyter"
+
+
+[[package]]
+description = "Linux tool enabling reproducible experiments (packer)"
+conda-forge = "reprozip"
+pypi = "reprozip"
+
+
+[[package]]
+description = "Persistent cache for requests library"
+conda-forge = "requests-cache"
+pypi = "requests-cache"
+
+
+[[package]]
+description = "Download files using requests and save them to a target path"
+conda-forge = "requests_download"
+pypi = "requests_download"
+
+
+[[package]]
+description = "Import exceptions from potentially bundled packages in requests."
+conda-forge = "requestsexceptions"
+pypi = "requestsexceptions"
+
+
+[[package]]
+description = "An FTP transport adapter for use with the Python Requests library"
+conda-forge = "requests-ftp"
+pypi = "requests-ftp"
+
+
+[[package]]
+description = "Asynchronous Python HTTP for Humans."
+conda-forge = "requests-futures"
+pypi = "requests-futures"
+
+
+[[package]]
+description = "requests-mock provides a building block to stub out the HTTP requests portions of your testing code."
+conda-forge = "requests-mock"
+pypi = "requests-mock"
+
+
+[[package]]
+description = "NTLM authentication support for Requests."
+conda-forge = "requests_ntlm"
+pypi = "requests_ntlm"
+
+
+[[package]]
+description = "OAuthlib authentication support for Requests."
+conda-forge = "requests-oauthlib"
+pypi = "requests-oauthlib"
+
+
+[[package]]
+description = "This library adds PKCS#12 support to the Python requests library."
+conda-forge = "requests_pkcs12"
+pypi = "requests_pkcs12"
+
+
+[[package]]
+description = "Python HTTP for Humans."
+conda-forge = "requests"
+pypi = "requests"
+
+
+[[package]]
+description = "A utility belt for advanced users of python-requests."
+conda-forge = "requests-toolbelt"
+pypi = "requests-toolbelt"
+
+
+[[package]]
+description = "Use requests to talk HTTP via a UNIX domain socket"
+conda-forge = "requests-unixsocket"
+pypi = "requests-unixsocket"
+
+
+[[package]]
+description = "Python tool to find and list requirements of a Python project"
+conda-forge = "requirements-detector"
+pypi = "requirements-detector"
+
+
+[[package]]
+description = "This is a small Python module for parsing Pip requirement files."
+conda-forge = "requirements-parser"
+pypi = "requirements-parser"
+
+
+[[package]]
+description = "Efficient signal resampling"
+conda-forge = "resampy"
+pypi = "resampy"
+
+
+[[package]]
+description = "Learning mechanical vibrations through computation."
+conda-forge = "resonance"
+pypi = "resonance"
+
+
+[[package]]
+description = "Lint reStructuredText files"
+conda-forge = "restructuredtext_lint"
+pypi = "restructuredtext_lint"
+
+
+[[package]]
+description = "Data Retriever"
+conda-forge = "retriever"
+pypi = "retriever"
+
+
+[[package]]
+description = "Simplify the task of adding retry behavior to just about anything."
+conda-forge = "retrying"
+pypi = "retrying"
+
+
+[[package]]
+description = "Re-apply type annotations from .pyi stubs to your codebase."
+conda-forge = "retype"
+pypi = "retype"
+
+
+[[package]]
+description = "Format dates according to the RFC 3339"
+conda-forge = "rfc3339"
+pypi = "rfc3339"
+
+
+[[package]]
+description = "Validating URI References per RFC 3986"
+conda-forge = "rfc3986"
+pypi = "rfc3986"
+
+
+[[package]]
+description = "Parsing and validation of URIs (RFC 3986) and IRIs (RFC 3987)"
+conda-forge = "rfc3987"
+pypi = "rfc3987"
+
+
+[[package]]
+description = "Code to compute permutation and drop-column importances in Python scikit-learn random forests"
+conda-forge = "rfpimp"
+pypi = "rfpimp"
+
+
+[[package]]
+description = "Rickshaw is an automated driver for Cyclus"
+conda-forge = "rickshaw"
+pypi = "rickshaw"
+
+
+[[package]]
+description = "RISE: Live Reveal.js Jupyter/IPython Slideshow Extension"
+conda-forge = "rise"
+pypi = "rise"
+
+
+[[package]]
+description = "Fast javascript minifier for Python"
+conda-forge = "rjsmin"
+pypi = "rjsmin"
+
+
+[[package]]
+description = "RNAtools is a Python package for the manipulation of RNA files."
+conda-forge = "rnatools"
+pypi = "RNAtools"
+
+
+[[package]]
+description = "Your friendly neighborhood web scraper"
+conda-forge = "robobrowser"
+pypi = "robobrowser"
+
+
+[[package]]
+description = "Linter for robot framework plain text files"
+conda-forge = "robotframework-lint"
+pypi = "robotframework-lint"
+
+
+[[package]]
+description = "A generic test automation framework"
+conda-forge = "robotframework"
+pypi = "robotframework"
+
+
+[[package]]
+description = "Web testing library for Robot Framework"
+conda-forge = "robotframework-seleniumlibrary"
+pypi = "robotframework-seleniumlibrary"
+
+
+[[package]]
+description = "Robot Framework test library for SSH and SFTP"
+conda-forge = "robotframework-sshlibrary"
+pypi = "robotframework-sshlibrary"
+
+
+[[package]]
+description = "Tool for validating that executed Robot Framework test cases have expected\nstatuses and log messages.\n"
+conda-forge = "robotstatuschecker"
+pypi = "robotstatuschecker"
+
+
+[[package]]
+description = "A python refactoring library"
+conda-forge = "rope"
+pypi = "rope"
+
+
+[[package]]
+description = "Routing Recognition and Generation Tools"
+conda-forge = "routes"
+pypi = "Routes"
+
+
+[[package]]
+description = "Perform quaternion operations using numpy arrays"
+conda-forge = "rowan"
+pypi = "rowan"
+
+
+[[package]]
+description = "Path manipulation library"
+conda-forge = "rpaths"
+pypi = "rpaths"
+
+
+[[package]]
+description = "A pure Python Lex/Yacc that works with RPython"
+conda-forge = "rply"
+pypi = "rply"
+
+
+[[package]]
+description = "Python interface to the R language (embedded R)"
+conda-forge = "rpy2"
+pypi = "rpy2"
+
+
+[[package]]
+description = "Pure-Python RSA implementation"
+conda-forge = "rsa"
+pypi = "rsa"
+
+
+[[package]]
+description = "Bistatic first order radiative transfer model"
+conda-forge = "rt1"
+pypi = "rt1"
+
+
+[[package]]
+description = "A YAML package for Python. It is a derivative of Kirill Simonov's PyYAML 3.11 which supports YAML1.1"
+conda-forge = "ruamel.yaml"
+pypi = "ruamel.yaml"
+
+
+[[package]]
+description = "Run IPython notebooks from the command line"
+conda-forge = "runipy"
+pypi = "runipy"
+
+
+[[package]]
+description = "Reactive Extensions (Rx) for Python"
+conda-forge = "rx"
+pypi = "Rx"
+
+
+[[package]]
+description = "A S3-backed ContentsManager implementation for Jupyter"
+conda-forge = "s3contents"
+pypi = "s3contents"
+
+
+[[package]]
+description = "Convenient Filesystem interface over S3"
+conda-forge = "s3fs"
+pypi = "s3fs"
+
+
+[[package]]
+description = "An Amazon S3 Transfer Manager"
+conda-forge = "s3transfer"
+pypi = "s3transfer"
+
+
+[[package]]
+description = "Salvus mesher for AxiSEM meshes"
+conda-forge = "salvus_mesher_lite"
+pypi = "salvus_mesher_lite"
+
+
+[[package]]
+description = "Async Python 3.5+ web server that's written to go fast"
+conda-forge = "sanic"
+pypi = "sanic"
+
+
+[[package]]
+description = "a wrapper for subprocess for interaction with external applications"
+conda-forge = "sarge"
+pypi = "sarge"
+
+
+[[package]]
+description = "A Jupyter kernel for SAS"
+conda-forge = "sas_kernel"
+pypi = "sas_kernel"
+
+
+[[package]]
+description = "A Python interface module to the SAS System"
+conda-forge = "saspy"
+pypi = "saspy"
+
+
+[[package]]
+description = "Meteorological processing package"
+conda-forge = "satpy"
+pypi = "satpy"
+
+
+[[package]]
+description = "scandir, a better directory iterator and faster os.walk()"
+conda-forge = "scandir"
+pypi = "scandir"
+
+
+[[package]]
+description = "Beautiful visualizations of how language differs among document types"
+conda-forge = "scattertext"
+pypi = "scattertext"
+
+
+[[package]]
+description = "A common interface for parallel processing pools"
+conda-forge = "schwimmbad"
+pypi = "schwimmbad"
+
+
+[[package]]
+description = "A Python package for exploring and analysing genetic variation data."
+conda-forge = "scikit-allel"
+pypi = "scikit-allel"
+
+
+[[package]]
+description = "Data structures, algorithms and educational resources for bioinformatics."
+conda-forge = "scikit-bio"
+pypi = "scikit-bio"
+
+
+[[package]]
+description = "The propose of this library is to allow the data analysis process more easy and automatic."
+conda-forge = "scikit-data"
+pypi = "scikit-data"
+
+
+[[package]]
+description = "DSP and Comm package."
+conda-forge = "scikit-dsp-comm"
+pypi = "scikit-dsp-comm"
+
+
+[[package]]
+description = "A garden for scikit-learn compatible trees"
+conda-forge = "scikit-garden"
+pypi = "scikit-garden"
+
+
+[[package]]
+description = "Image processing routines for SciPy."
+conda-forge = "scikit-image"
+pypi = "scikit-image"
+
+
+[[package]]
+description = "A sklearn-compatible Python implementation of Multifactor Dimensionality\nReduction (MDR) for feature construction.\n"
+conda-forge = "scikit-mdr"
+pypi = "scikit-MDR"
+
+
+[[package]]
+description = "Sequential model-based optimization toolbox."
+conda-forge = "scikit-optimize"
+pypi = "scikit-optimize"
+
+
+[[package]]
+description = "An intuitive library to add plotting functionality to scikit-learn objects."
+conda-forge = "scikit-plot"
+pypi = "scikit-plot"
+
+
+[[package]]
+description = "This is a scikit for the Weighted Orthogonal Procrustes Problem."
+conda-forge = "scikit-procrustes"
+pypi = "scikit-procrustes"
+
+
+[[package]]
+description = "A Python scikit for building and analyzing recommender systems."
+conda-forge = "scikit-surprise"
+pypi = "scikit-surprise"
+
+
+[[package]]
+description = "Collection of algorithms and functions for ultrafast electron diffraction"
+conda-forge = "scikit-ued"
+pypi = "scikit-ued"
+
+
+[[package]]
+description = "Helper library for writing dynamic, flexible workflows in luigi"
+conda-forge = "sciluigi"
+pypi = "sciluigi"
+
+
+[[package]]
+description = "Missing SciPy functionalities"
+conda-forge = "scipy-sugar"
+pypi = "scipy-sugar"
+
+
+[[package]]
+description = "Open Source next-generation build tool."
+conda-forge = "scons"
+pypi = "scons"
+
+
+[[package]]
+description = "A high-level Python Screen Scraping framework"
+conda-forge = "scrapy"
+pypi = "Scrapy"
+
+
+[[package]]
+description = "This is a set of Python bindings for the scrypt key derivation function."
+conda-forge = "scrypt"
+pypi = "scrypt"
+
+
+[[package]]
+description = "Python interface for SCS, which solves convex cone problems"
+conda-forge = "scs"
+pypi = "scs"
+
+
+[[package]]
+description = "Work with the Scientific Data Format in Python"
+conda-forge = "sdf"
+pypi = "sdf"
+
+
+[[package]]
+description = "Statistical data visualization"
+conda-forge = "seaborn"
+pypi = "seaborn"
+
+
+[[package]]
+description = "Provides a way for securely storing passwords and other secrets."
+conda-forge = "secretstorage"
+pypi = "SecretStorage"
+
+
+[[package]]
+description = "Segno is a QR Code and Micro QR Code encoder which has no further dependencies."
+conda-forge = "segno"
+pypi = "segno"
+
+
+[[package]]
+description = "Python bindings for the Selenium WebDriver for automating web browser interaction."
+conda-forge = "selenium"
+pypi = "selenium"
+
+
+[[package]]
+description = "Python package to work with Semantic Versioning"
+conda-forge = "semver"
+pypi = "semver"
+
+
+[[package]]
+description = "Python library to natively send files to Trash (or Recycle bin) on all platforms."
+conda-forge = "send2trash"
+pypi = "Send2Trash"
+
+
+[[package]]
+description = "SendGrid library for Python"
+conda-forge = "sendgrid"
+pypi = "sendgrid"
+
+
+[[package]]
+description = "Various objects to denote special meanings in python"
+conda-forge = "sentinels"
+pypi = "sentinels"
+
+
+[[package]]
+description = "Astronomical source extraction and photometry library"
+conda-forge = "sep"
+pypi = "sep"
+
+
+[[package]]
+description = "Base class with serialization helpers for user-defined Python objects"
+conda-forge = "serializable"
+pypi = "serializable"
+
+
+[[package]]
+description = "Serialization based on ast.literal_eval"
+conda-forge = "serpent"
+pypi = "serpent"
+
+
+[[package]]
+description = "ridiculously fast object serialization"
+conda-forge = "serpy"
+pypi = "serpy"
+
+
+[[package]]
+description = "An utility that accesses files on a HTTP server and stores them locally for reuse"
+conda-forge = "serverfiles"
+pypi = "serverfiles"
+
+
+[[package]]
+description = "Service identity verification for pyOpenSSL."
+conda-forge = "service_identity"
+pypi = "service_identity"
+
+
+[[package]]
+description = "A module for retrieving program settings from various sources in a consistant method."
+conda-forge = "setoptconf"
+pypi = "setoptconf"
+
+
+[[package]]
+description = "A library to allow customization of the process title."
+conda-forge = "setproctitle"
+pypi = "setproctitle"
+
+
+[[package]]
+description = "Setuptools revision control system plugin for Git"
+conda-forge = "setuptools-git"
+pypi = "setuptools-git"
+
+
+[[package]]
+description = "Use Markdown for your project description"
+conda-forge = "setuptools_markdown"
+pypi = "setuptools-markdown"
+
+
+[[package]]
+description = "Use Markdown for your project description"
+conda-forge = "setuptools-markdown"
+pypi = "setuptools-markdown"
+
+
+[[package]]
+description = "Download, build, install, upgrade, and uninstall Python packages"
+conda-forge = "setuptools"
+pypi = "setuptools"
+
+
+[[package]]
+description = "setuptools_scm plugin for git archives"
+conda-forge = "setuptools_scm_git_archive"
+pypi = "setuptools_scm_git_archive"
+
+
+[[package]]
+description = "The blessed package to manage your versions by scm tags."
+conda-forge = "setuptools_scm"
+pypi = "setuptools_scm"
+
+
+[[package]]
+description = "S-expression parser for Python"
+conda-forge = "sexpdata"
+pypi = "sexpdata"
+
+
+[[package]]
+description = "Get E(B-V) values from the Schlegel et al (1998) galactic dust map"
+conda-forge = "sfdmap"
+pypi = "sfdmap"
+
+
+[[package]]
+description = "Client library for OpenStack containing Infra business logic"
+conda-forge = "shade"
+pypi = "shade"
+
+
+[[package]]
+description = "Python package for manipulation and analysis of geometric objects in the Cartesian plane."
+conda-forge = "shapely"
+pypi = "Shapely"
+
+
+[[package]]
+description = "Fills missing values in a pandas DataFrame using a Restricted Boltzmann Machine."
+conda-forge = "sherlockml-boltzmannclean"
+pypi = "sherlockml-boltzmannclean"
+
+
+[[package]]
+description = "Python subprocess interface"
+conda-forge = "sh"
+pypi = "sh"
+
+
+[[package]]
+description = "shutil.which for those not using Python 3.3 yet."
+conda-forge = "shutilwhich"
+pypi = "shutilwhich"
+
+
+[[package]]
+description = "SigOpt Python API Client"
+conda-forge = "sigopt"
+pypi = "sigopt"
+
+
+[[package]]
+description = "The silx project aims at providing a collection of Python packages to support the development of data assessment, reduction and analysis applications at synchrotron radiation facilities."
+conda-forge = "silx"
+pypi = "silx"
+
+
+[[package]]
+description = "Simulated datasets of DNA"
+conda-forge = "simdna"
+pypi = "simdna"
+
+
+[[package]]
+description = "Simhash and near-duplicate detection"
+conda-forge = "simhash-py"
+pypi = "simhash-py"
+
+
+[[package]]
+description = "This is a Python implementation of [Simhash](http://www.wwwconference.org/www2007/papers/paper215.pdf)"
+conda-forge = "simhash"
+pypi = "simhash"
+
+
+[[package]]
+description = "Simple generic functions (similar to Python's own len(), pickle.dump(), etc.)"
+conda-forge = "simplegeneric"
+pypi = "simplegeneric"
+
+
+[[package]]
+description = "Simple, fast, extensible JSON encoder/decoder for Python"
+conda-forge = "simplejson"
+pypi = "simplejson"
+
+
+[[package]]
+description = "A Simple KML creator"
+conda-forge = "simplekml"
+pypi = "simplekml"
+
+
+[[package]]
+description = "Simple Salesforce is a basic Salesforce.com REST API client. The goal is to provide a very low-level interface to the API, returning an ordered dictionary of the API JSON response."
+conda-forge = "simple-salesforce"
+pypi = "simple-salesforce"
+
+
+[[package]]
+description = "A general-purpose forward-time population genetics simulation environment"
+conda-forge = "simupop"
+pypi = "simuPOP"
+
+
+[[package]]
+description = "This library brings functools.singledispatch from Python 3.4 to Python 2.6-3.3."
+conda-forge = "singledispatch"
+pypi = "singledispatch"
+
+
+[[package]]
+description = "A collection of Python utilities for interacting with the Unidata technology stack."
+conda-forge = "siphon"
+pypi = "siphon"
+
+
+[[package]]
+description = "Python 2 and 3 compatibility utilities"
+conda-forge = "six"
+pypi = "six"
+
+
+[[package]]
+description = "skan: skeleton analysis in Python"
+conda-forge = "skan"
+pypi = "skan"
+
+
+[[package]]
+description = "Python Library for Model Agnostic Interpretation"
+conda-forge = "skater"
+pypi = "skater"
+
+
+[[package]]
+description = "Ski Jump Design Tool For Specified Equivalent Fall Height"
+conda-forge = "skijumpdesign"
+pypi = "skijumpdesign"
+
+
+[[package]]
+description = "lightning is a library for large-scale linear classification, regression and ranking in Python."
+conda-forge = "sklearn-contrib-lightning"
+pypi = "sklearn-contrib-lightning"
+
+
+[[package]]
+description = "A Python implementation of Jerome Friedman's\nMultivariate Adaptive Regression Splines\n"
+conda-forge = "sklearn-contrib-py-earth"
+pypi = "sklearn-contrib-py-earth"
+
+
+[[package]]
+description = "Analysis of object skeletons"
+conda-forge = "sknw"
+pypi = "sknw"
+
+
+[[package]]
+description = "A scikit-learn-compatible Python implementation of ReBATE, a suite of\nRelief-based feature selection algorithms for Machine Learning.\n"
+conda-forge = "skrebate"
+pypi = "skrebate"
+
+
+[[package]]
+description = "Video Processing in Python"
+conda-forge = "sk-video"
+pypi = "sk-video"
+
+
+[[package]]
+description = "Elegant astronomy for Python"
+conda-forge = "skyfield"
+pypi = "skyfield"
+
+
+[[package]]
+description = "Python client for Slack.com"
+conda-forge = "slackclient"
+pypi = "slackclient"
+
+
+[[package]]
+description = "Slack API client"
+conda-forge = "slacker"
+pypi = "slacker"
+
+
+[[package]]
+description = "A generic slugifier."
+conda-forge = "slugify"
+pypi = "slugify"
+
+
+[[package]]
+description = "A library that makes consuming a REST API easier and more convenient"
+conda-forge = "slumber"
+pypi = "slumber"
+
+
+[[package]]
+description = "Python library for efficient streaming of large files"
+conda-forge = "smart_open"
+pypi = "smart_open"
+
+
+[[package]]
+description = "Python with the SmartyPants"
+conda-forge = "smartypants"
+pypi = "smartypants"
+
+
+[[package]]
+description = "Simulation Modelling Integration Framework"
+conda-forge = "smif"
+pypi = "smif"
+
+
+[[package]]
+description = "A pure python implementation of a sliding window memory map manager"
+conda-forge = "smmap2"
+pypi = "smmap2"
+
+
+[[package]]
+description = "A pure git implementation of a sliding window memory map manager."
+conda-forge = "smmap"
+pypi = "smmap"
+
+
+[[package]]
+description = "A simple python library for sending and receiving signals"
+conda-forge = "smokesignal"
+pypi = "smokesignal"
+
+
+[[package]]
+description = "Transform timestamps with a simple DSL"
+conda-forge = "snaptime"
+pypi = "snaptime"
+
+
+[[package]]
+description = "Python library for supernova cosmology"
+conda-forge = "sncosmo"
+pypi = "sncosmo"
+
+
+[[package]]
+description = "Snowball stemming library collection for Python"
+conda-forge = "snowballstemmer"
+pypi = "snowballstemmer"
+
+
+[[package]]
+description = "Snuggs are s-expressions for NumPy."
+conda-forge = "snuggs"
+pypi = "snuggs"
+
+
+[[package]]
+description = "Python Social Authentication, Django integration."
+conda-forge = "social-auth-app-django"
+pypi = "social-auth-app-django"
+
+
+[[package]]
+description = "Python social authentication made simple."
+conda-forge = "social-auth-core"
+pypi = "social-auth-core"
+
+
+[[package]]
+description = "Massively parallel self-organizing maps: accelerate training on multicore CPUs and GPUs"
+conda-forge = "somoclu"
+pypi = "somoclu"
+
+
+[[package]]
+description = "Python Sorted Collections"
+conda-forge = "sortedcollections"
+pypi = "sortedcollections"
+
+
+[[package]]
+description = "Python Sorted Container Types: SortedList, SortedDict, and SortedSet"
+conda-forge = "sortedcontainers"
+pypi = "sortedcontainers"
+
+
+[[package]]
+description = "Analyze, visualize and process sound field data recorded by spherical microphone arrays"
+conda-forge = "sound_field_analysis"
+pypi = "sound_field_analysis"
+
+
+[[package]]
+description = "Industrial-strength Natural Language Processing"
+conda-forge = "spacy"
+pypi = "spacy"
+
+
+[[package]]
+description = "Jupyter magics and kernels for working with remote Spark clusters"
+conda-forge = "sparkmagic"
+pypi = "sparkmagic"
+
+
+[[package]]
+description = "SPARQL Endpoint interface to Python for use with rdflib"
+conda-forge = "sparqlwrapper"
+pypi = "SPARQLWrapper"
+
+
+[[package]]
+description = "Sparse multi-dimensional arrays for the PyData ecosystem"
+conda-forge = "sparse"
+pypi = "sparse"
+
+
+[[package]]
+description = "Implements a lazy string for python useful for use with gettext"
+conda-forge = "speaklater"
+pypi = "speaklater"
+
+
+[[package]]
+description = "This package provides a set of lightweight utilities for working with spectroscopic data in astronomy. Based on the astropy affiliated package template."
+conda-forge = "speclite"
+pypi = "speclite"
+
+
+[[package]]
+description = "A package for interaction with spectral cubes"
+conda-forge = "spectral-cube"
+pypi = "spectral-cube"
+
+
+[[package]]
+description = "A Python module for hyperspectral image processing."
+conda-forge = "spectral"
+pypi = "spectral"
+
+
+[[package]]
+description = "Color scales and color conversion made easy for Python."
+conda-forge = "spectra"
+pypi = "spectra"
+
+
+[[package]]
+description = "Spectrum Analysis Tools"
+conda-forge = "spectrum"
+pypi = "spectrum"
+
+
+[[package]]
+description = "Astropy affiliated package for astronomical spectral operations."
+conda-forge = "specutils"
+pypi = "specutils"
+
+
+[[package]]
+description = "A PEG-based parser interpreter with memoization."
+conda-forge = "speg"
+pypi = "speg"
+
+
+[[package]]
+description = "Space symmetry groups spglib module."
+conda-forge = "spglib"
+pypi = "spglib"
+
+
+[[package]]
+description = "A Python package for handling spherical polygons that represent arbitrary regions of the sky"
+conda-forge = "spherical-geometry"
+pypi = "spherical-geometry"
+
+
+[[package]]
+description = "Sphinx extension that automatically documents argparse commands and options"
+conda-forge = "sphinx-argparse"
+pypi = "sphinx-argparse"
+
+
+[[package]]
+description = "Sphinx extensions and configuration specific to the Astropy project"
+conda-forge = "sphinx-astropy"
+pypi = "sphinx-astropy"
+
+
+[[package]]
+description = "Sphinx auto API documentation generator"
+conda-forge = "sphinx-autoapi"
+pypi = "sphinx-autoapi"
+
+
+[[package]]
+description = "Watch a Sphinx directory and rebuild the documentation when a change is detected. Also includes a livereload enabled web server."
+conda-forge = "sphinx-autobuild"
+pypi = "sphinx-autobuild"
+
+
+[[package]]
+description = "Type hints (PEP 484) support for the Sphinx autodoc extension"
+conda-forge = "sphinx-autodoc-typehints"
+pypi = "sphinx-autodoc-typehints"
+
+
+[[package]]
+description = "Sphinx extension for auto-generating API documentation for entire modules"
+conda-forge = "sphinx-automodapi"
+pypi = "sphinx-automodapi"
+
+
+[[package]]
+description = "A Sphinx extension for running sphinx-apidoc on each build."
+conda-forge = "sphinxcontrib-apidoc"
+pypi = "sphinxcontrib-apidoc"
+
+
+[[package]]
+description = "Doxygen / Sphinx bridge, with autodoc and autosummary"
+conda-forge = "sphinxcontrib-autodoc_doxygen"
+pypi = "sphinxcontrib-autodoc_doxygen"
+
+
+[[package]]
+description = "Documenting CLI programs"
+conda-forge = "sphinxcontrib-autoprogram"
+pypi = "sphinxcontrib-autoprogram"
+
+
+[[package]]
+description = "A Sphinx extension for BibTeX style citations."
+conda-forge = "sphinxcontrib-bibtex"
+pypi = "sphinxcontrib-bibtex"
+
+
+[[package]]
+description = "A Sphinx extension for running sphinx-apidoc on each build."
+conda-forge = "sphinxcontrib-dotnetdomain"
+pypi = "sphinxcontrib-dotnetdomain"
+
+
+[[package]]
+description = "Sphinx extension sphinxcontrib-golangdomain"
+conda-forge = "sphinxcontrib-golangdomain"
+pypi = "sphinxcontrib-golangdomain"
+
+
+[[package]]
+description = "Sphinx/Paver integration"
+conda-forge = "sphinxcontrib-paverutils"
+pypi = "sphinxcontrib-paverutils"
+
+
+[[package]]
+description = "Sphinx extension to include program output"
+conda-forge = "sphinxcontrib-programoutput"
+pypi = "sphinxcontrib-programoutput"
+
+
+[[package]]
+description = "Sphinx extension to output reST files."
+conda-forge = "sphinxcontrib-restbuilder"
+pypi = "sphinxcontrib-restbuilder"
+
+
+[[package]]
+description = "This package contains sphinxcontrb.spelling, a spelling checker for Sphinx-based documentation."
+conda-forge = "sphinxcontrib-spelling"
+pypi = "sphinxcontrib-spelling"
+
+
+[[package]]
+description = "Sphinx API for Web Apps"
+conda-forge = "sphinxcontrib-websupport"
+pypi = "sphinxcontrib-websupport"
+
+
+[[package]]
+description = "Sphinx extension for automatic generation of an example gallery"
+conda-forge = "sphinx-gallery"
+pypi = "sphinx-gallery"
+
+
+[[package]]
+description = "A Sphinx extension for linking to your project's issue tracker"
+conda-forge = "sphinx-issues"
+pypi = "sphinx-issues"
+
+
+[[package]]
+description = "A sphinx theme plugin support extension. #sphinxjp"
+conda-forge = "sphinxjp.themecore"
+pypi = "sphinxjp.themecore"
+
+
+[[package]]
+description = "A sphinx theme for HTML presentation style"
+conda-forge = "sphinxjp.themes.impressjs"
+pypi = "sphinxjp.themes.impressjs"
+
+
+[[package]]
+description = "A sphinx theme based on solarized color scheme."
+conda-forge = "sphinxjp.themes.solarized"
+pypi = "sphinxjp.themes.solarized"
+
+
+[[package]]
+description = "Create an examples gallery with sphinx from Jupyter Notebooks"
+conda-forge = "sphinx-nbexamples"
+pypi = "sphinx-nbexamples"
+
+
+[[package]]
+description = "Sphinx is a tool that makes it easy to create intelligent and beautiful documentation"
+conda-forge = "sphinx"
+pypi = "Sphinx"
+
+
+[[package]]
+description = "ReadTheDocs.org theme for Sphinx, 2013 version."
+conda-forge = "sphinx_rtd_theme"
+pypi = "sphinx_rtd_theme"
+
+
+[[package]]
+description = "The NASA JPL NAIF SPICE toolkit wrapper written in Python"
+conda-forge = "spiceypy"
+pypi = "spiceypy"
+
+
+[[package]]
+description = "A simple subprocess launcher with optional DRMAA support."
+conda-forge = "splauncher"
+pypi = "splauncher"
+
+
+[[package]]
+description = "A library for dealing with splittable files"
+conda-forge = "splits"
+pypi = "splits"
+
+
+[[package]]
+description = "A Python logging handler that sends your logs to Splunk"
+conda-forge = "splunk_handler"
+pypi = "53e106e2e0805777b6bb9cde1245bed7f94e479125e94f9d7d09cd3f16a5"
+
+
+[[package]]
+description = "One-Dimensional Statistical Parametric Mapping in Python"
+conda-forge = "spm1d"
+pypi = "spm1d"
+
+
+[[package]]
+description = "Sputnik: a data package manager library"
+conda-forge = "sputnik"
+pypi = "sputnik"
+
+
+[[package]]
+description = "Jupyter kernels for the Spyder console"
+conda-forge = "spyder-kernels"
+pypi = "spyder-kernels"
+
+
+[[package]]
+description = "Spyder plugin that integrates the Python line profiler."
+conda-forge = "spyder-line-profiler"
+pypi = "spyder-line-profiler"
+
+
+[[package]]
+description = "Spyder plugin that integrates the Python memory profiler."
+conda-forge = "spyder-memory-profiler"
+pypi = "spyder-memory-profiler"
+
+
+[[package]]
+description = "Jupyter notebook integration with Spyder"
+conda-forge = "spyder-notebook"
+pypi = "spyder-notebook"
+
+
+[[package]]
+description = "Scientific PYthon Development EnviRonment"
+conda-forge = "spyder"
+pypi = "spyder"
+
+
+[[package]]
+description = "Spyder-IDE plugin for Markdown reports using Pweave."
+conda-forge = "spyder-reports"
+pypi = "spyder-reports"
+
+
+[[package]]
+description = "Spyder plugin for displaying system terminals."
+conda-forge = "spyder-terminal"
+pypi = "spyder-terminal"
+
+
+[[package]]
+description = "Spyder plugin that integrates popular unit test frameworks."
+conda-forge = "spyder-unittest"
+pypi = "spyder-unittest"
+
+
+[[package]]
+description = "Scala magics and kernel for jupyter"
+conda-forge = "spylon-kernel"
+pypi = "spylon-kernel"
+
+
+[[package]]
+description = "Utilities to work with Scala/Java code with py4j"
+conda-forge = "spylon"
+pypi = "spylon"
+
+
+[[package]]
+description = "A transport and architecture agnostic rpc library that focuses on exposing public services with a well-defined API."
+conda-forge = "spyne"
+pypi = "spyne"
+
+
+[[package]]
+description = "Web Application Framework for simple user interface."
+conda-forge = "dataspyre"
+pypi = "DataSpyre"
+
+
+[[package]]
+description = "Database schema migration for SQLAlchemy"
+conda-forge = "sqlalchemy-migrate"
+pypi = "sqlalchemy-migrate"
+
+
+[[package]]
+description = "Database Abstraction Library."
+conda-forge = "sqlalchemy"
+pypi = "SQLAlchemy"
+
+
+[[package]]
+description = "Various utility functions for SQLAlchemy."
+conda-forge = "sqlalchemy-utils"
+pypi = "SQLAlchemy-Utils"
+
+
+[[package]]
+description = "Object-Relational Manager, aka database wrapper"
+conda-forge = "sqlobject"
+pypi = "SQLObject"
+
+
+[[package]]
+description = "A non-validating SQL parser module for Python."
+conda-forge = "sqlparse"
+pypi = "sqlparse"
+
+
+[[package]]
+description = "Python client library for reading Server Sent Event streams."
+conda-forge = "sseclient"
+pypi = "sseclient"
+
+
+[[package]]
+description = "Super fact SSH library. Based on libssh2."
+conda-forge = "ssh2-python"
+pypi = "ssh2-python"
+
+
+[[package]]
+description = "jinja based static site generator"
+conda-forge = "staticjinja"
+pypi = "staticjinja"
+
+
+[[package]]
+description = "A really simple WSGI way to serve static (or mixed) content."
+conda-forge = "static"
+pypi = "static"
+
+
+[[package]]
+description = "Non-parametric morphological diagnostics of galaxy images"
+conda-forge = "statmorph"
+pypi = "statmorph"
+
+
+[[package]]
+description = "A Python client for statsd"
+conda-forge = "statsd"
+pypi = "statsd"
+
+
+[[package]]
+description = "Statistical computations and models for use with SciPy"
+conda-forge = "statsmodels"
+pypi = "statsmodels"
+
+
+[[package]]
+description = "A statuspage generator that lets you host your statuspage for free on Github."
+conda-forge = "statuspage"
+pypi = "statuspage"
+
+
+[[package]]
+description = "Python Utilities for parsing STEEM blockchain"
+conda-forge = "steemdata"
+pypi = "steemdata"
+
+
+[[package]]
+description = "Official python steem library"
+conda-forge = "steem"
+pypi = "steem"
+
+
+[[package]]
+description = "Manage dynamic plugins for Python applications"
+conda-forge = "stevedore"
+pypi = "stevedore"
+
+
+[[package]]
+description = "The Next Generation Spectral Timing Software"
+conda-forge = "stingray"
+pypi = "stingray"
+
+
+[[package]]
+description = "Raise asynchronous exceptions in other thread, control the timeout of\nblocks or callables with a context manager or a decorator\n"
+conda-forge = "stopit"
+pypi = "stopit"
+
+
+[[package]]
+description = "Manage streaming data, optionally with Dask and Pandas"
+conda-forge = "streamz"
+pypi = "streamz"
+
+
+[[package]]
+description = "Strict, simple, lightweight RFC3339 functions"
+conda-forge = "strict-rfc3339"
+pypi = "strict-rfc3339"
+
+
+[[package]]
+description = "Type-safe YAML parser and validator."
+conda-forge = "strictyaml"
+pypi = "strictyaml"
+
+
+[[package]]
+description = "Enables JupyterHub to spawn single-user notebook servers without being root"
+conda-forge = "sudospawner"
+pypi = "sudospawner"
+
+
+[[package]]
+description = "Lightweight SOAP client (Jurko's fork)."
+conda-forge = "suds-jurko"
+pypi = "suds-jurko"
+
+
+[[package]]
+description = "Python for Solar Physics"
+conda-forge = "sunpy"
+pypi = "sunpy"
+
+
+[[package]]
+description = "Super State Machine gives you utilities to build finite state machines."
+conda-forge = "super_state_machine"
+pypi = "super_state_machine"
+
+
+[[package]]
+description = "A pure-Python library for reading and converting SVG"
+conda-forge = "svglib"
+pypi = "svglib"
+
+
+[[package]]
+description = "Python SVG editor that allows to automatically create publication ready\ncomposite SVG figures.\n"
+conda-forge = "svgutils"
+pypi = "svgutils"
+
+
+[[package]]
+description = "A Python library to create SVG drawings."
+conda-forge = "svgwrite"
+pypi = "svgwrite"
+
+
+[[package]]
+description = "Python library for symbolic mathematics"
+conda-forge = "sympy"
+pypi = "sympy"
+
+
+[[package]]
+description = "Sysv_ipc gives Python programs access to System V semaphores, shared memory and message queues"
+conda-forge = "sysv_ipc"
+pypi = "sysv_ipc"
+
+
+[[package]]
+description = "Create Table 1 for research papers in Python"
+conda-forge = "tableone"
+pypi = "tableone"
+
+
+[[package]]
+description = "A utility library for working with Table Schema in Python"
+conda-forge = "tableschema-py"
+pypi = "tableschema"
+
+
+[[package]]
+description = "Format agnostic tabular data library (XLS, JSON, YAML, CSV)"
+conda-forge = "tablib"
+pypi = "tablib"
+
+
+[[package]]
+description = "Simple wrapper of tabula-java: extract table from PDF into pandas DataFrame"
+conda-forge = "tabula-py"
+pypi = "tabula-py"
+
+
+[[package]]
+description = "Pretty-print tabular data in Python, a library and a command-line utility."
+conda-forge = "tabulate"
+pypi = "tabulate"
+
+
+[[package]]
+description = "Consistent interface for stream reading and writing tabular data (csv/xls/json/etc)"
+conda-forge = "tabulator-py"
+pypi = "tabulator"
+
+
+[[package]]
+description = "Traceback serialization library."
+conda-forge = "tblib"
+pypi = "tblib"
+
+
+[[package]]
+description = "generate temporary directories"
+conda-forge = "tempdir"
+pypi = "tempdir"
+
+
+[[package]]
+description = "A small templating language"
+conda-forge = "tempita"
+pypi = "Tempita"
+
+
+[[package]]
+description = "Objects and routines pertaining to date and time (tempora)"
+conda-forge = "tempora"
+pypi = "tempora"
+
+
+[[package]]
+description = "Retry a flaky function whenever an exception occurs until it works"
+conda-forge = "tenacity"
+pypi = "tenacity"
+
+
+[[package]]
+description = "tensorboard for pytorch"
+conda-forge = "tensorboardx"
+pypi = "tensorboardX"
+
+
+[[package]]
+description = "A library for transfer learning by reusing parts of TensorFlow models."
+conda-forge = "tensorflow-hub"
+pypi = "tensorflow_hub"
+
+
+[[package]]
+description = "ANSII Color formatting for output in terminal."
+conda-forge = "termcolor"
+pypi = "termcolor"
+
+
+[[package]]
+description = "Terminals served by tornado websockets"
+conda-forge = "terminado"
+pypi = "terminado"
+
+
+[[package]]
+description = "Generate simple tables in terminals from a nested list of strings."
+conda-forge = "terminaltables"
+pypi = "terminaltables"
+
+
+[[package]]
+description = "A collection of helpers and mock objects for unit tests and doc tests."
+conda-forge = "testfixtures"
+pypi = "testfixtures"
+
+
+[[package]]
+description = "Testpath is a collection of utilities for Python code working with files and commands."
+conda-forge = "testpath"
+pypi = "testpath"
+
+
+[[package]]
+description = "Extensions to the Python standard library unit testing framework"
+conda-forge = "testtools"
+pypi = "testtools"
+
+
+[[package]]
+description = "Parses valid LaTeX and provides a variety of BeautifulSoup-esque methods and\nPythonic idioms for iterating and searching the parse tree.\n"
+conda-forge = "texsoup"
+pypi = "TexSoup"
+
+
+[[package]]
+description = "higher-level NLP built on spaCy"
+conda-forge = "textacy"
+pypi = "textacy"
+
+
+[[package]]
+description = "Simple, Pythonic text processing. Sentiment analysis, part-of-speech tagging, noun phrase parsing, and more."
+conda-forge = "textblob"
+pypi = "textblob"
+
+
+[[package]]
+description = "TextDistance – python library for comparing distance between two or more sequences by many algorithms."
+conda-forge = "textdistance"
+pypi = "textdistance"
+
+
+[[package]]
+description = "Python module for creating simple ASCII tables"
+conda-forge = "texttable"
+pypi = "texttable"
+
+
+[[package]]
+description = "Recurrent neural network language modeling tool implemented using Theano"
+conda-forge = "theanolm"
+pypi = "TheanoLM"
+
+
+[[package]]
+description = "Optimizing compiler for evaluating mathematical expressions on CPUs and GPUs."
+conda-forge = "theano"
+pypi = "Theano"
+
+
+[[package]]
+description = "Lowlevel implementation of (transition-based and histogram) reweighting analyis methods for Python."
+conda-forge = "thermotools"
+pypi = "thermotools"
+
+
+[[package]]
+description = "thinc: Learn super-sparse multi-class models"
+conda-forge = "thinc"
+pypi = "thinc"
+
+
+[[package]]
+description = "Modules supporting books by Allen Downey"
+conda-forge = "thinkx"
+pypi = "thinkx"
+
+
+[[package]]
+description = "Pure python implementation of Apache Thrift."
+conda-forge = "thriftpy"
+pypi = "thriftpy"
+
+
+[[package]]
+description = "Python bindings for the Apache Thrift RPC system"
+conda-forge = "thrift"
+pypi = "thrift"
+
+
+[[package]]
+description = "Thrift SASL module that implements TSaslClientTransport"
+conda-forge = "thrift_sasl"
+pypi = "thrift_sasl"
+
+
+[[package]]
+description = "Easy headers, inspired by the tidy data specification."
+conda-forge = "tidy_headers"
+pypi = "tidy_headers"
+
+
+[[package]]
+description = "Read and write image data from and to TIFF files."
+conda-forge = "tifffile"
+pypi = "tifffile"
+
+
+[[package]]
+description = "Easily parse/access a subset of data from a folder of TIFFs"
+conda-forge = "tifffolder"
+pypi = "tifffolder"
+
+
+[[package]]
+description = "Apache Tika Python library"
+conda-forge = "tika"
+pypi = "tika"
+
+
+[[package]]
+description = "Timeout decorator"
+conda-forge = "timeout-decorator"
+pypi = "timeout-decorator"
+
+
+[[package]]
+description = "A lightweight python library for finding the timezone of any point on earth (coordinates), but fast! "
+conda-forge = "timezonefinder"
+pypi = "timezonefinder"
+
+
+[[package]]
+description = "Low-level CSS parser for Python"
+conda-forge = "tinycss2"
+pypi = "tinycss2"
+
+
+[[package]]
+description = "Tinycss is a complete yet simple CSS parser for Python."
+conda-forge = "tinycss"
+pypi = "tinycss"
+
+
+[[package]]
+description = "TinyDB is a tiny, document oriented database optimized for your happiness :)"
+conda-forge = "tinydb"
+pypi = "tinydb"
+
+
+[[package]]
+description = "Simple, fast, extensible JSON encoder/decoder for Python"
+conda-forge = "tinyrpc"
+pypi = "tinyrpc"
+
+
+[[package]]
+description = "Tiny Python benchmarking library"
+conda-forge = "tinytimer"
+pypi = "tinytimer"
+
+
+[[package]]
+description = "Accurately separate the TLD from the registered domain andsubdomains of a URL, using the Public Suffix List."
+conda-forge = "tldextract"
+pypi = "tldextract"
+
+
+[[package]]
+description = "tlslite implements SSL and TLS."
+conda-forge = "tlslite"
+pypi = "tlslite"
+
+
+[[package]]
+description = "A toolkit for ETL curation for the tranSMART data warehouse."
+conda-forge = "tmtk"
+pypi = "tmtk"
+
+
+[[package]]
+description = "A JIT implementation for Marshmallow to speed up dumping and loading objects."
+conda-forge = "toastedmarshmallow"
+pypi = "toastedmarshmallow"
+
+
+[[package]]
+description = "A wrapper around the stdlib `tokenize` which roundtrips."
+conda-forge = "tokenize-rt"
+pypi = "tokenize-rt"
+
+
+[[package]]
+description = "Python lib for TOML."
+conda-forge = "toml"
+pypi = "toml"
+
+
+[[package]]
+description = "A functional standard library for Python."
+conda-forge = "toolz"
+pypi = "toolz"
+
+
+[[package]]
+description = "Implements a topological sort algorithm."
+conda-forge = "toposort"
+pypi = "toposort"
+
+
+[[package]]
+description = "Deserialize torch-serialized objects from Python."
+conda-forge = "torchfile"
+pypi = "torchfile"
+
+
+[[package]]
+description = "Tornado is a Python web framework and asynchronous networking library,\noriginally developed at FriendFeed.\n"
+conda-forge = "tornado"
+pypi = "tornado"
+
+
+[[package]]
+description = "Synchronization primitives for Tornado coroutines"
+conda-forge = "toro"
+pypi = "toro"
+
+
+[[package]]
+description = "Building newsfiles for your project"
+conda-forge = "towncrier"
+pypi = "towncrier"
+
+
+[[package]]
+description = "virtualenv-based automation of test activities"
+conda-forge = "tox"
+pypi = "tox"
+
+
+[[package]]
+description = "A Python tool that automatically creates and optimizes Machine Learning pipelines using genetic programming."
+conda-forge = "tpot"
+pypi = "TPOT"
+
+
+[[package]]
+description = "A Fast, Extensible Progress Meter"
+conda-forge = "tqdm"
+pypi = "tqdm"
+
+
+[[package]]
+description = "Backports of the traceback module"
+conda-forge = "traceback2"
+pypi = "traceback2"
+
+
+[[package]]
+description = "Python particle tracking toolkit"
+conda-forge = "trackpy"
+pypi = "trackpy"
+
+
+[[package]]
+description = "Ultimate transformation library that supports validation, contexts and aiohttp"
+conda-forge = "trafaret"
+pypi = "trafaret"
+
+
+[[package]]
+description = "Configuration system for Python applications"
+conda-forge = "traitlets"
+pypi = "traitlets"
+
+
+[[package]]
+description = "TraitsUI - Traits-capable windowing framework"
+conda-forge = "traitsui"
+pypi = "traitsui"
+
+
+[[package]]
+description = "Trait types for NumPy, SciPy and friends"
+conda-forge = "traittypes"
+pypi = "traittypes"
+
+
+[[package]]
+description = "Transaction management for Python"
+conda-forge = "transaction"
+pypi = "transaction"
+
+
+[[package]]
+description = "Command line interface to FreeDesktop.org Trash."
+conda-forge = "trash-cli"
+pypi = "trash-cli"
+
+
+[[package]]
+description = "Python requests like API built on top of Twisted's HTTP client"
+conda-forge = "treq"
+pypi = "treq"
+
+
+[[package]]
+description = "Import, export, process, analyze and view triangular meshes."
+conda-forge = "trimesh"
+pypi = "trimesh"
+
+
+[[package]]
+description = "A re-implementation of the asyncio mainloop on top of Trio"
+conda-forge = "trio_asyncio"
+pypi = "trio_asyncio"
+
+
+[[package]]
+description = "An async/await-native I/O library for humans and snake people"
+conda-forge = "trio"
+pypi = "trio"
+
+
+[[package]]
+description = "Pytroll imaging library"
+conda-forge = "trollimage"
+pypi = "trollimage"
+
+
+[[package]]
+description = "Port of the Tulip project (asyncio module, PEP 3156) on Python 2"
+conda-forge = "trollius"
+pypi = "trollius"
+
+
+[[package]]
+description = "String parser/formatter for PyTroll packages"
+conda-forge = "trollsift"
+pypi = "trollsift"
+
+
+[[package]]
+description = "Massively Parallel Trotter-Suzuki Solver"
+conda-forge = "trottersuzuki"
+pypi = "trottersuzuki"
+
+
+[[package]]
+description = "Automatic extraction of relevant features from time series"
+conda-forge = "tsfresh"
+pypi = "tsfresh"
+
+
+[[package]]
+description = "A machine learning toolkit dedicated to time-series data"
+conda-forge = "tslearn"
+pypi = "tslearn"
+
+
+[[package]]
+description = "An easy-to-use Python library for accessing the Twitter API."
+conda-forge = "tweepy"
+pypi = "tweepy"
+
+
+[[package]]
+description = "Collection of utilities for interacting with PyPI"
+conda-forge = "twine"
+pypi = "twine"
+
+
+[[package]]
+description = "event-driven networking engine"
+conda-forge = "twisted"
+pypi = "Twisted"
+
+
+[[package]]
+description = "Actively maintained, pure Python wrapper for the Twitter API. Supports both normal and streaming Twitter APIs"
+conda-forge = "twython"
+pypi = "twython"
+
+
+[[package]]
+description = "Compatibility API between asyncio/Twisted/Trollius"
+conda-forge = "txaio"
+pypi = "txaio"
+
+
+[[package]]
+description = "Helper functions for runtime type checking"
+conda-forge = "typechecks"
+pypi = "typechecks"
+
+
+[[package]]
+description = "a fork of Python 2 and 3 ast modules with type comment support"
+conda-forge = "typed-ast"
+pypi = "typed-ast"
+
+
+[[package]]
+description = "Filters to enhance web typography, including support for Django & Jinja templates"
+conda-forge = "typogrify"
+pypi = "typogrify"
+
+
+[[package]]
+description = "tzinfo object for the local timezone"
+conda-forge = "tzlocal"
+pypi = "tzlocal"
+
+
+[[package]]
+description = "Python port of Browserscope's user agent parser"
+conda-forge = "ua-parser"
+pypi = "ua-parser"
+
+
+[[package]]
+description = "Very fast avro file to dataframe reader"
+conda-forge = "uavro"
+pypi = "uavro"
+
+
+[[package]]
+description = "Fast RFC3339 compliant Python date-time library"
+conda-forge = "udatetime"
+pypi = "udatetime"
+
+
+[[package]]
+description = "Ultra fast JSON decoder and encoder written in C with Python bindings"
+conda-forge = "ujson"
+pypi = "ujson"
+
+
+[[package]]
+description = "UK Postcode parser"
+conda-forge = "ukpostcodeparser"
+pypi = "UkPostcodeParser"
+
+
+[[package]]
+description = "Clean, simple, and fast access to public hydrology and climatology data"
+conda-forge = "ulmo"
+pypi = "ulmo"
+
+
+[[package]]
+description = "Date Api that support Hijri Umalqurra calendar."
+conda-forge = "umalqurra"
+pypi = "umalqurra"
+
+
+[[package]]
+description = "Simple, fast, extensible JSON encoder/decoder for Python"
+conda-forge = "umap-learn"
+pypi = "umap-learn"
+
+
+[[package]]
+description = "Transparent calculations with uncertainties on the quantities involved (aka \"error propagation\"); fast calculation of derivatives."
+conda-forge = "uncertainties"
+pypi = "uncertainties"
+
+
+[[package]]
+description = "Scan filesystem for changes not committed to version control"
+conda-forge = "uncommitted"
+pypi = "uncommitted"
+
+
+[[package]]
+description = "Drop-in replacement for csv module which supports unicode strings"
+conda-forge = "unicodecsv"
+pypi = "unicodecsv"
+
+
+[[package]]
+description = "unicodedata backport/updates to python 3 and python 2."
+conda-forge = "unicodedata2"
+pypi = "unicodedata2"
+
+
+[[package]]
+description = "ASCII transliterations of Unicode text"
+conda-forge = "unidecode"
+pypi = "Unidecode"
+
+
+[[package]]
+description = "unittest2pytest is a tool that helps rewriting Python unittest test-cases into pytest test-cases."
+conda-forge = "unittest2pytest"
+pypi = "unittest2pytest"
+
+
+[[package]]
+description = "Recent features of the unittest package backported to Python <= 3.4."
+conda-forge = "unittest2"
+pypi = "unittest2"
+
+
+[[package]]
+description = "Handle, manipulate, and convert data with units in Python"
+conda-forge = "unyt"
+pypi = "unyt"
+
+
+[[package]]
+description = "A python module that will check for package updates."
+conda-forge = "update_checker"
+pypi = "update_checker"
+
+
+[[package]]
+description = "URI templates."
+conda-forge = "uritemplate.py"
+pypi = "uritemplate.py"
+
+
+[[package]]
+description = "URI Templates"
+conda-forge = "uritemplate"
+pypi = "uritemplate"
+
+
+[[package]]
+description = "RFC 3986 compliant, Unicode-aware, scheme-agnostic replacement for urlparse"
+conda-forge = "uritools"
+pypi = "uritools"
+
+
+[[package]]
+description = "HTTP library with thread-safe connection pooling, file post, and more."
+conda-forge = "urllib3"
+pypi = "urllib3"
+
+
+[[package]]
+description = "A utility class for manipulating URLs."
+conda-forge = "urlobject"
+pypi = "URLObject"
+
+
+[[package]]
+description = "A full-featured console (xterm et al.) user interface library"
+conda-forge = "urwid"
+pypi = "urwid"
+
+
+[[package]]
+description = "Parse US addresses using conditional random fields"
+conda-forge = "usaddress"
+pypi = "usaddress"
+
+
+[[package]]
+description = "Anonymous usage statistics collecter"
+conda-forge = "usagestats"
+pypi = "usagestats"
+
+
+[[package]]
+description = "Access the USGS inventory service"
+conda-forge = "usgs"
+pypi = "usgs"
+
+
+[[package]]
+description = "US state meta information and other fun stuff"
+conda-forge = "us"
+pypi = "us"
+
+
+[[package]]
+description = "Python distribution of the MatLab package UTide"
+conda-forge = "utide"
+pypi = "UTide"
+
+
+[[package]]
+description = "Bidirectional UTM-WGS84 converter for python."
+conda-forge = "utm"
+pypi = "utm"
+
+
+[[package]]
+description = "Ultra fast implementation of asyncio event loop on top of libuv."
+conda-forge = "uvloop"
+pypi = "uvloop"
+
+
+[[package]]
+description = "The uWSGI project aims at developing a full stack for building hosting\nservices. Application servers (for various programming languages and\nprotocols), proxies, process managers and monitors are all implemented.\n"
+conda-forge = "uwsgi"
+pypi = "uWSGI"
+
+
+[[package]]
+description = "Astronomy related transformations and FITS file support for vaex"
+conda-forge = "vaex-astro"
+pypi = "vaex-astro"
+
+
+[[package]]
+description = "Core of vaex"
+conda-forge = "vaex-core"
+pypi = "vaex-core"
+
+
+[[package]]
+description = "Distributed dataset for vaex"
+conda-forge = "vaex-distributed"
+pypi = "vaex-distributed"
+
+
+[[package]]
+description = "hdf5 file support for vaex"
+conda-forge = "vaex-hdf5"
+pypi = "vaex-hdf5"
+
+
+[[package]]
+description = "Jupyter notebook and Jupyter lab support for vaex"
+conda-forge = "vaex-jupyter"
+pypi = "vaex-jupyter"
+
+
+[[package]]
+description = "Webserver and client for vaex for a remote dataset"
+conda-forge = "vaex-server"
+pypi = "vaex-server"
+
+
+[[package]]
+description = "Graphical user interface for vaex based on Qt"
+conda-forge = "vaex-ui"
+pypi = "vaex-ui"
+
+
+[[package]]
+description = "Visualization for vaex"
+conda-forge = "vaex-viz"
+pypi = "vaex-viz"
+
+
+[[package]]
+description = "Validate_email is a package for Python that check if an email is valid, properly formatted and really exists."
+conda-forge = "validate_email"
+pypi = "validate_email"
+
+
+[[package]]
+description = "A general purpose python data validator"
+conda-forge = "validictory"
+pypi = "validictory"
+
+
+[[package]]
+description = "Automatically mock your HTTP interactions to simplify and speed up testing"
+conda-forge = "vcrpy"
+pypi = "vcrpy"
+
+
+[[package]]
+description = "Take version numbers from version control."
+conda-forge = "vcversioner"
+pypi = "33162c0a7b28a4d8c83da07bc2b12cee58c120b4a9e8bba31c41c8d35a16"
+
+
+[[package]]
+description = "Vector math utilities for Python built on NumPy"
+conda-forge = "vectormath"
+pypi = "vectormath"
+
+
+[[package]]
+description = "IPyVega3: An IPython/Jupyter widget for Vega 3 and Vega-Lite 2"
+conda-forge = "vega3"
+pypi = "vega3"
+
+
+[[package]]
+description = "A Python package for offline access to Vega datasets"
+conda-forge = "vega_datasets"
+pypi = "vega_datasets"
+
+
+[[package]]
+description = "An IPython/Jupyter widget for Vega and Vega-Lite"
+conda-forge = "vega"
+pypi = "vega"
+
+
+[[package]]
+description = "Verbose logging level for Python's logging module."
+conda-forge = "verboselogs"
+pypi = "verboselogs"
+
+
+[[package]]
+description = "Easy VCS-based management of project version strings"
+conda-forge = "versioneer"
+pypi = "versioneer"
+
+
+[[package]]
+description = "Version information for Jupyter notebooks"
+conda-forge = "version_information"
+pypi = "version_information"
+
+
+[[package]]
+description = "Smart replacement for plain tuple used in __version__"
+conda-forge = "versiontools"
+pypi = "versiontools"
+
+
+[[package]]
+description = "A native Python client for the Vertica database."
+conda-forge = "vertica-python"
+pypi = "vertica-python"
+
+
+[[package]]
+description = "A Python to Vega translator."
+conda-forge = "vincent"
+pypi = "vincent"
+
+
+[[package]]
+description = "Python promises"
+conda-forge = "vine"
+pypi = "vine"
+
+
+[[package]]
+description = "A tree Python library"
+conda-forge = "viridis"
+pypi = "viridis"
+
+
+[[package]]
+description = "script to clone virtualenvs."
+conda-forge = "virtualenv-clone"
+pypi = "virtualenv-clone"
+
+
+[[package]]
+description = "A tool for visualizing live, rich data for Torch and Numpy."
+conda-forge = "visdom"
+pypi = "visdom"
+
+
+[[package]]
+description = "A tiny pythonic visitor implementation."
+conda-forge = "visitor"
+pypi = "visitor"
+
+
+[[package]]
+description = "VisPy is a high-performance interactive 2D/3D data visualization library."
+conda-forge = "vispy"
+pypi = "vispy"
+
+
+[[package]]
+description = "Visvis - the object oriented approach to visualization"
+conda-forge = "visvis"
+pypi = "visvis"
+
+
+[[package]]
+description = "A full-featured Python package for parsing and creating iCalendar and vCard files"
+conda-forge = "vobject"
+pypi = "vobject"
+
+
+[[package]]
+description = "Voluptuous is a Python data validation library"
+conda-forge = "voluptuous"
+pypi = "voluptuous"
+
+
+[[package]]
+description = "Find dead code"
+conda-forge = "vulture"
+pypi = "vulture"
+
+
+[[package]]
+description = "Access Warcraft 3 replay files from Python 2 or 3"
+conda-forge = "w3g"
+pypi = "w3g"
+
+
+[[package]]
+description = "A set of helpers for baking your Django Wagtail site out as flat files"
+conda-forge = "wagtail-bakery"
+pypi = "wagtail-bakery"
+
+
+[[package]]
+description = "A Django content management system focused on flexibility and user experience "
+conda-forge = "wagtail"
+pypi = "wagtail"
+
+
+[[package]]
+description = "Production-quality pure-Python WSGI server"
+conda-forge = "waitress"
+pypi = "waitress"
+
+
+[[package]]
+description = "Common interface to the WakaTime api."
+conda-forge = "wakatime"
+pypi = "wakatime"
+
+
+[[package]]
+description = "Command line tools and libraries for handling and manipulating WARC files (and HTTP contents)"
+conda-forge = "warctools"
+pypi = "warctools"
+
+
+[[package]]
+description = "Python object model built on JSON schema and JSON patch."
+conda-forge = "warlock"
+pypi = "warlock"
+
+
+[[package]]
+description = "Filesystem events monitoring"
+conda-forge = "watchdog"
+pypi = "watchdog"
+
+
+[[package]]
+description = "IPython magic function to print date/time stamps and various system information."
+conda-forge = "watermark"
+pypi = "watermark"
+
+
+[[package]]
+description = "Command-line tool that lets you download the entire Wayback Machine archive for a given URL."
+conda-forge = "waybackpack"
+pypi = "waybackpack"
+
+
+[[package]]
+description = "WCSAxes is a framework for making plots of Astronomical data in Matplotlib."
+conda-forge = "wcsaxes"
+pypi = "wcsaxes"
+
+
+[[package]]
+description = "Measures number of Terminal column cells of wide-character codes."
+conda-forge = "wcwidth"
+pypi = "wcwidth"
+
+
+[[package]]
+description = "A friendly library for parsing HTTP request arguments, with built-in support for popular web frameworks"
+conda-forge = "webargs"
+pypi = "webargs"
+
+
+[[package]]
+description = "Media asset management for Python, with glue code for various web frameworks"
+conda-forge = "webassets"
+pypi = "webassets"
+
+
+[[package]]
+description = "Library for working with HTML/CSS color formats in Python."
+conda-forge = "webcolors"
+pypi = "webcolors"
+
+
+[[package]]
+description = "WebDAV client, based on original package https://github.com/designerror/webdav-client-python but uses requests instead of PyCURL"
+conda-forge = "webdavclient2"
+pypi = "webdavclient2"
+
+
+[[package]]
+description = "WSGI request and response object"
+conda-forge = "webob"
+pypi = "WebOb"
+
+
+[[package]]
+description = "web.py is a web framework for Python that is as simple as it is powerful."
+conda-forge = "web.py"
+pypi = "web.py"
+
+
+[[package]]
+description = "Launch web apps making them look like desktop apps."
+conda-forge = "webruntime"
+pypi = "webruntime"
+
+
+[[package]]
+description = "WebSocket client for python. hybi13 is supported."
+conda-forge = "websocket-client"
+pypi = "websocket_client"
+
+
+[[package]]
+description = "Pandas-based utility to calculate weighted means, medians, distributions, standard deviations, and more."
+conda-forge = "weightedcalcs"
+pypi = "weightedcalcs"
+
+
+[[package]]
+description = "The Python WSGI Utility Library."
+conda-forge = "werkzeug"
+pypi = "Werkzeug"
+
+
+[[package]]
+description = "The WFDB Python Toolbox"
+conda-forge = "wfdb"
+pypi = "wfdb"
+
+
+[[package]]
+description = "A built-package format for Python."
+conda-forge = "wheel"
+pypi = "wheel"
+
+
+[[package]]
+description = "This package provides cross-platform cross-python shutil.which functionality.\n"
+conda-forge = "whichcraft"
+pypi = "whichcraft"
+
+
+[[package]]
+description = "Radically simplified static file serving for Python web apps"
+conda-forge = "whitenoise"
+pypi = "whitenoise"
+
+
+[[package]]
+description = "Whoosh is a fast, featureful full-text indexing and searching library implemented in pure Python"
+conda-forge = "whoosh"
+pypi = "Whoosh"
+
+
+[[package]]
+description = "Interactive Widgets for Jupyter"
+conda-forge = "widgetsnbextension"
+pypi = "widgetsnbextension"
+
+
+[[package]]
+description = "Wikipedia is a Python library that makes it easy to access and parse data from Wikipedia."
+conda-forge = "wikipedia"
+pypi = "wikipedia"
+
+
+[[package]]
+description = "A unified interface to Python image libraries"
+conda-forge = "willow"
+pypi = "Willow"
+
+
+[[package]]
+description = "Python Matplotlib, Numpy library to manage wind data, draw windrose."
+conda-forge = "windrose"
+pypi = "windrose"
+
+
+[[package]]
+description = "A tool to programmatically control windows inside X"
+conda-forge = "wmctrl"
+pypi = "wmctrl"
+
+
+[[package]]
+description = "The core wq command line interface (CLI)."
+conda-forge = "wq.core"
+pypi = "wq.core"
+
+
+[[package]]
+description = "Open Source Library for Weather Radar Data Processing"
+conda-forge = "wradlib"
+pypi = "wradlib"
+
+
+[[package]]
+description = "Module for decorators, wrappers and monkey patching."
+conda-forge = "wrapt"
+pypi = "wrapt"
+
+
+[[package]]
+description = "Tools for loading, processing, and plotting multidimensional spectroscopy data."
+conda-forge = "wrighttools"
+pypi = "WrightTools"
+
+
+[[package]]
+description = "WebSocket client and server library for Python 2, 3, and PyPy"
+conda-forge = "ws4py"
+pypi = "ws4py"
+
+
+[[package]]
+description = "WSAccell is WebSocket accelerator for AutobahnPython, and ws4py"
+conda-forge = "wsaccel"
+pypi = "wsaccel"
+
+
+[[package]]
+description = "A WSGI Proxy with various http client backends"
+conda-forge = "wsgiproxy2"
+pypi = "WSGIProxy2"
+
+
+[[package]]
+description = "Appengine tools for WTForms"
+conda-forge = "wtforms-appengine"
+pypi = "wtforms-appengine"
+
+
+[[package]]
+description = "A flexible forms validation and rendering library for Python"
+conda-forge = "wtforms"
+pypi = "WTForms"
+
+
+[[package]]
+description = "WTForms integration for peewee models"
+conda-forge = "wtf-peewee"
+pypi = "wtf-peewee"
+
+
+[[package]]
+description = "Capture C-level stdout/stderr in Python"
+conda-forge = "wurlitzer"
+pypi = "wurlitzer"
+
+
+[[package]]
+description = "A wxPython widget for browsing a XNAT repository"
+conda-forge = "wxnatpy"
+pypi = "wxnatpy"
+
+
+[[package]]
+description = "Cross platform GUI toolkit for Python, \"Phoenix\" version"
+conda-forge = "wxpython"
+pypi = "wxPython"
+
+
+[[package]]
+description = "Advanced / experimental extensions to xarray"
+conda-forge = "xarray-extras"
+pypi = "xarray-extras"
+
+
+[[package]]
+description = "N-D labeled arrays and datasets in Python."
+conda-forge = "xarray"
+pypi = "xarray"
+
+
+[[package]]
+description = "Python wrapper for extended filesystem attributes"
+conda-forge = "xattr"
+pypi = "xattr"
+
+
+[[package]]
+description = "xarray interface for bpch files"
+conda-forge = "xbpch"
+pypi = "xbpch"
+
+
+[[package]]
+description = "Variables defined by the XDG Base Directory Specification"
+conda-forge = "xdg"
+pypi = "xdg"
+
+
+[[package]]
+description = "Monitor code metrics for Python on your CI server"
+conda-forge = "xenon"
+pypi = "xenon"
+
+
+[[package]]
+description = "Universal Regridder for Geospatial Data"
+conda-forge = "xesmf"
+pypi = "xesmf"
+
+
+[[package]]
+description = "Scalable, Portable and Distributed Gradient Boosting (GBDT, GBRT or GBM) Library, for\nPython, R, Java, Scala, C++ and more. Runs on single machine, Hadoop, Spark, Flink\nand DataFlow\n"
+conda-forge = "xgboost"
+pypi = "xgboost"
+
+
+[[package]]
+description = "General Circulation Model Postprocessing with xarray"
+conda-forge = "xgcm"
+pypi = "xgcm"
+
+
+[[package]]
+description = "Library for developers to extract data from Microsoft Excel (tm) spreadsheet files"
+conda-forge = "xlrd"
+pypi = "xlrd"
+
+
+[[package]]
+description = "A Python module for creating Excel XLSX files"
+conda-forge = "xlsxwriter"
+pypi = "XlsxWriter"
+
+
+[[package]]
+description = "Writing data and formatting information to Excel files"
+conda-forge = "xlwt"
+pypi = "xlwt"
+
+
+[[package]]
+description = "PyUnit-based test runner with JUnit like XML reporting."
+conda-forge = "xmlrunner"
+pypi = "xmlrunner"
+
+
+[[package]]
+description = "An XML Schema validator and decoder"
+conda-forge = "xmlschema"
+pypi = "xmlschema"
+
+
+[[package]]
+description = "Makes working with XML feel like you are working with JSON"
+conda-forge = "xmltodict"
+pypi = "xmltodict"
+
+
+[[package]]
+description = "A new XNAT client that exposes XNAT objects/functions as python objects/functions."
+conda-forge = "xnat"
+pypi = "xnat"
+
+
+[[package]]
+description = "Python utility functions for slices."
+conda-forge = "xnumpy"
+pypi = "xnumpy"
+
+
+[[package]]
+description = "run headless display inside X virtual framebuffer (Xvfb)"
+conda-forge = "xvfbwrapper"
+pypi = "xvfbwrapper"
+
+
+[[package]]
+description = "A modern Cron replacement that is Docker-friendly"
+conda-forge = "yacron"
+pypi = "yacron"
+
+
+[[package]]
+description = "Yet Another Iterator Library for Python."
+conda-forge = "yail"
+pypi = "yail"
+
+
+[[package]]
+description = "A linter for YAML files."
+conda-forge = "yamllint"
+pypi = "yamllint"
+
+
+[[package]]
+description = "Loaders and dumpers for PyYAML"
+conda-forge = "yamlloader"
+pypi = "yamlloader"
+
+
+[[package]]
+description = "Yet Another Python Profiler"
+conda-forge = "yappi"
+pypi = "yappi"
+
+
+[[package]]
+description = "Yet another plugin system"
+conda-forge = "yapsy"
+pypi = "Yapsy"
+
+
+[[package]]
+description = "A semi hard Cornish cheese, also queries PyPI (PyPI client)"
+conda-forge = "yarg"
+pypi = "yarg"
+
+
+[[package]]
+description = "Yet another URL library"
+conda-forge = "yarl"
+pypi = "yarl"
+
+
+[[package]]
+description = "Estimates the inertial properties of a human."
+conda-forge = "yeadon"
+pypi = "yeadon"
+
+
+[[package]]
+description = "YouTube video downloader"
+conda-forge = "youtube-dl"
+pypi = "youtube_dl"
+
+
+[[package]]
+description = "jq wrapper for YAML and XML documents"
+conda-forge = "yq"
+pypi = "yq"
+
+
+[[package]]
+description = "An implementation of chunked, compressed, N-dimensional arrays for Python."
+conda-forge = "zarr"
+pypi = "zarr"
+
+
+[[package]]
+description = "Basic inter-process locks"
+conda-forge = "zc.lockfile"
+pypi = "zc.lockfile"
+
+
+[[package]]
+description = "Structured Configuration Library"
+conda-forge = "zconfig"
+pypi = "ZConfig"
+
+
+[[package]]
+description = "Daemon process control library and tools for Unix-based systems"
+conda-forge = "zdaemon"
+pypi = "zdaemon"
+
+
+[[package]]
+description = "A fast and modern Python SOAP client"
+conda-forge = "zeep"
+pypi = "zeep"
+
+
+[[package]]
+description = "ZEO - Single-server client-server database server for ZODB"
+conda-forge = "zeo"
+pypi = "ZEO"
+
+
+[[package]]
+description = "Composable Dictionary Classes"
+conda-forge = "zict"
+pypi = "zict"
+
+
+[[package]]
+description = "Fork of Python 3 pickle module."
+conda-forge = "zodbpickle"
+pypi = "zodbpickle"
+
+
+[[package]]
+description = "ZODB, a Python object-oriented database"
+conda-forge = "zodb"
+pypi = "ZODB"
+
+
+[[package]]
+description = "Construct ZODB storage instances from URIs."
+conda-forge = "zodburi"
+pypi = "zodburi"
+
+
+[[package]]
+description = "Interfaces for Python"
+conda-forge = "zope.interface"
+pypi = "zope.interface"
+
+
+[[package]]
+description = "Zopfli module for python"
+conda-forge = "zopfli"
+pypi = "zopfli"
+
+
+[[package]]
+description = "Zstandard bindings for Python"
+conda-forge = "zstandard"
+pypi = "zstandard"
+
+

--- a/db/conda-pypi.toml
+++ b/db/conda-pypi.toml
@@ -1,0 +1,2870 @@
+[[package]]
+description = "Abseil Python Common Libraries, see https://github.com/abseil/abseil-py."
+conda = "absl-py"
+pypi = "absl-py"
+
+[[package]]
+description = "Advanced Enumerations (compatible with Python's stdlib Enum), NamedTuples,"
+conda = "aenum"
+pypi = "aenum"
+
+[[package]]
+description = "Matrices describing affine transformation of the plane."
+conda = "affine"
+pypi = "affine"
+
+[[package]]
+description = "agate-dbf adds read support for dbf files to agate."
+conda = "agate-dbf"
+pypi = "agate-dbf"
+
+[[package]]
+description = "agate-excel adds read support for Excel files (xls and xlsx) to agate."
+conda = "agate-excel"
+pypi = "agate-excel"
+
+[[package]]
+description = "A data analysis library that is optimized for humans instead of machines."
+conda = "agate"
+pypi = "agate"
+
+[[package]]
+description = "agate-sql adds SQL read/write support to agate."
+conda = "agate-sql"
+pypi = "agate-sql"
+
+[[package]]
+description = "Async client for aws services using botocore and aiohttp"
+conda = "aiobotocore"
+pypi = "aiobotocore"
+
+[[package]]
+description = "File support for asyncio"
+conda = "aiofiles"
+pypi = "aiofiles"
+
+[[package]]
+description = "Async http client/server framework (asyncio)"
+conda = "aiohttp"
+pypi = "aiohttp"
+
+[[package]]
+description = "Configurable, Python 2+3 compatible Sphinx theme."
+conda = "alabaster"
+pypi = "alabaster"
+
+[[package]]
+description = "A database migration tool for SQLAlchemy."
+conda = "alembic"
+pypi = "alembic"
+
+[[package]]
+description = "Tool for encapsulating, running, and reproducing data science projects"
+conda = "anaconda-project"
+pypi = "anaconda-project"
+
+[[package]]
+description = "Convert text with ANSI color codes to HTML or to LaTeX."
+conda = "ansi2html"
+pypi = "ansi2html"
+
+[[package]]
+description = "Wraps the best available JSON implementation available in a common interface"
+conda = "anyjson"
+pypi = "anyjson"
+
+[[package]]
+description = "PyQt4/PyQt5 compatibility layer."
+conda = "anyqt"
+pypi = "AnyQt"
+
+[[package]]
+description = "With apipkg you can control the exported namespace of a python package and greatly reduce the number of imports for your users."
+conda = "apipkg"
+pypi = "apipkg"
+
+[[package]]
+description = "A small Python module for determining appropriate platform-specific dirs."
+conda = "appdirs"
+pypi = "appdirs"
+
+[[package]]
+description = "application tools"
+conda = "apptools"
+pypi = "apptools"
+
+[[package]]
+description = "Bash tab completion for argparse"
+conda = "argcomplete"
+pypi = "argcomplete"
+
+[[package]]
+description = "The secure Argon2 password hashing algorithm."
+conda = "argon2_cffi"
+pypi = "argon2_cffi"
+
+[[package]]
+description = "Better dates & times for Python."
+conda = "arrow"
+pypi = "arrow"
+
+[[package]]
+description = "Python ASN.1 library with a focus on performance and a pythonic API"
+conda = "asn1crypto"
+pypi = "asn1crypto"
+
+[[package]]
+description = "Read, rewrite, and write Python ASTs nicely"
+conda = "astor"
+pypi = "astor"
+
+[[package]]
+description = "A abstract syntax tree for Python with inference support."
+conda = "astroid"
+pypi = "astroid"
+
+[[package]]
+description = "A fast PostgreSQL Database Client Library for Python/asyncio."
+conda = "asyncpgsa"
+pypi = "asyncpgsa"
+
+[[package]]
+description = "Timeout context manager for asyncio programs"
+conda = "async-timeout"
+pypi = "async-timeout"
+
+[[package]]
+description = "Atomic file writes."
+conda = "atomicwrites"
+pypi = "atomicwrites"
+
+[[package]]
+description = "attrs is the Python package that will bring back the joy of writing classes by relieving you from the drudgery of implementing object protocols (aka dunder methods)."
+conda = "attrs"
+pypi = "attrs"
+
+[[package]]
+description = "self-service finite-state machines for the programmer on the go"
+conda = "automat"
+pypi = "Automat"
+
+[[package]]
+description = "An Auto-Visualization library for pandas dataframes"
+conda = "autovizwidget"
+pypi = "autovizwidget"
+
+[[package]]
+description = "Microsoft Azure Client Libraries for Python"
+conda = "azure"
+pypi = "azure"
+
+[[package]]
+description = "Utilities to internationalize and localize Python applications"
+conda = "babel"
+pypi = "Babel"
+
+[[package]]
+description = "Specifications for callback functions passed in to an API"
+conda = "backcall"
+pypi = "backcall"
+
+[[package]]
+description = "A backport of recent additions to the `collections.abc` module."
+conda = "backports_abc"
+pypi = "backports_abc"
+
+[[package]]
+description = "Backport of functools.lru_cache from Python 3.3 as published at ActiveState."
+conda = "backports.functools_lru_cache"
+pypi = "backports.functools_lru_cache"
+
+[[package]]
+description = "Backport of Python 3.3's 'lzma' module for XZ/LZMA compressed files."
+conda = "backports.lzma"
+pypi = "backports.lzma"
+
+[[package]]
+description = "A backport of the get_terminal_size function from Python 3.3's shutil."
+conda = "backports.shutil_get_terminal_size"
+pypi = "backports.shutil_get_terminal_size"
+
+[[package]]
+description = "Backport of shutil.which from Python 3.3"
+conda = "backports.shutil_which"
+pypi = "backports.shutil_which"
+
+[[package]]
+description = "Backport of new features in Python's weakref module"
+conda = "backports.weakref"
+pypi = "backports.weakref"
+
+[[package]]
+description = "PyPI mirror client according to PEP 381"
+conda = "bandersnatch"
+pypi = "bandersnatch"
+
+[[package]]
+description = "A columnar data container that can be compressed"
+conda = "bcolz"
+pypi = "bcolz"
+
+[[package]]
+description = "modern password hashing for your software and your servers"
+conda = "bcrypt"
+pypi = "bcrypt"
+
+[[package]]
+description = "Python library designed for screen-scraping"
+conda = "beautifulsoup4"
+pypi = "beautifulsoup4"
+
+[[package]]
+description = "Collection of freely available tools for computational molecular biology"
+conda = "biopython"
+pypi = "biopython"
+
+[[package]]
+description = "efficient arrays of booleans -- C extension"
+conda = "bitarray"
+pypi = "bitarray"
+
+[[package]]
+description = "High level chart types built on top of Bokeh"
+conda = "bkcharts"
+pypi = "bkcharts"
+
+[[package]]
+description = "Easy, whitelist-based HTML-sanitizing tool"
+conda = "bleach"
+pypi = "bleach"
+
+[[package]]
+description = "Fast, simple object-to-object and broadcast signaling"
+conda = "blinker"
+pypi = "blinker"
+
+[[package]]
+description = "Statistical and novel interactive HTML plots for Python"
+conda = "bokeh"
+pypi = "bokeh"
+
+[[package]]
+description = "Amazon Web Services SDK for Python"
+conda = "boto3"
+pypi = "boto3"
+
+[[package]]
+description = "Low-level, data-driven core of boto 3."
+conda = "botocore"
+pypi = "botocore"
+
+[[package]]
+description = "Low-level, data-driven core of boto 3."
+conda = "botocore"
+pypi = "botocore"
+
+[[package]]
+description = "Low-level, data-driven core of boto 3."
+conda = "botocore"
+pypi = "botocore"
+
+[[package]]
+description = "Amazon Web Services Library"
+conda = "boto"
+pypi = "fe1db6a5ed53831b53b8a6695a8f134a58833cadb5f2740802bc3730ac15"
+
+[[package]]
+description = "Fast NumPy array functions written in Cython."
+conda = "bottleneck"
+pypi = "Bottleneck"
+
+[[package]]
+description = "scalable persistent object containers"
+conda = "btrees"
+pypi = "BTrees"
+
+[[package]]
+description = "Read and write bzip2-compressed files."
+conda = "bz2file"
+pypi = "bz2file"
+
+[[package]]
+description = "httplib2 caching algorithms for use with requests"
+conda = "cachecontrol"
+pypi = "CacheControl"
+
+[[package]]
+description = "A decorator for caching properties in classes."
+conda = "cached-property"
+pypi = "cached-property"
+
+[[package]]
+description = "Easily capture stdout/stderr of the current process and subprocesses."
+conda = "capturer"
+pypi = "capturer"
+
+[[package]]
+description = "Python package for providing Mozilla's CA Bundle."
+conda = "certifi"
+pypi = "certifi"
+
+[[package]]
+description = "Foreign Function Interface for Python calling C code."
+conda = "cffi"
+pypi = "cffi"
+
+[[package]]
+description = "Time-handling functionality from netcdf4-python"
+conda = "cftime"
+pypi = "cftime"
+
+[[package]]
+description = "Easy to use mocking, stubbing and spying framework."
+conda = "chai"
+pypi = "chai"
+
+[[package]]
+description = "A flexible framework of neural networks"
+conda = "chainer"
+pypi = "chainer"
+
+[[package]]
+description = "HTML/XML template engine for Python"
+conda = "chameleon"
+pypi = "Chameleon"
+
+[[package]]
+description = "Universal character encoding detector"
+conda = "chardet"
+pypi = "chardet"
+
+[[package]]
+description = "Highly-optimized, pure-python HTTP server"
+conda = "cheroot"
+pypi = "Cheroot"
+
+[[package]]
+description = "Object-Oriented HTTP framework"
+conda = "cherrypy"
+pypi = "CherryPy"
+
+[[package]]
+description = "A simple wrapper around optparse for powerful command line utilities."
+conda = "click"
+pypi = "click"
+
+[[package]]
+description = "An extension module for click to enable registering CLI commands via setuptools entry-points."
+conda = "click-plugins"
+pypi = "click-plugins"
+
+[[package]]
+description = "Click params for commmand line interfaces to GeoJSON."
+conda = "cligj"
+pypi = "cligj"
+
+[[package]]
+description = "Extended pickling support for Python objects"
+conda = "cloudpickle"
+pypi = "cloudpickle"
+
+[[package]]
+description = "A serialization, deserialization, and validation library"
+conda = "colander"
+pypi = "colander"
+
+[[package]]
+description = "Cross-platform colored terminal text."
+conda = "colorama"
+pypi = "colorama"
+
+[[package]]
+description = "Colored terminal output for Python's logging module"
+conda = "coloredlogs"
+pypi = "coloredlogs"
+
+[[package]]
+description = "Python color representations manipulation library (RGB, HSL, web, ...)"
+conda = "colour"
+pypi = "colour"
+
+[[package]]
+description = "Python parser for the CommonMark Markdown spec"
+conda = "commonmark"
+pypi = "CommonMark"
+
+[[package]]
+description = "replacement for argparse allowing options to be set via config files and/or env vars"
+conda = "configargparse"
+pypi = "ConfigArgParse"
+
+[[package]]
+description = "Config file reading, writing and validation."
+conda = "configobj"
+pypi = "configobj"
+
+[[package]]
+description = "This library brings the updated configparser from Python 3.5 to Python 2.6-3.5"
+conda = "configparser"
+pypi = "configparser"
+
+[[package]]
+description = "Symbolic constants in Python"
+conda = "constantly"
+pypi = "constantly"
+
+[[package]]
+description = "Backports and enhancements for the contextlib module"
+conda = "contextlib2"
+pypi = "contextlib2"
+
+[[package]]
+description = "build and document Web Services with Pyramid"
+conda = "cornice"
+pypi = "cornice"
+
+[[package]]
+description = "Code coverage measurement for Python"
+conda = "coverage"
+pypi = "coverage"
+
+[[package]]
+description = "Show coverage stats online via coveralls.io"
+conda = "coveralls"
+pypi = "coveralls"
+
+[[package]]
+description = "Provides cryptographic recipes and primitives to Python developers"
+conda = "cryptography"
+pypi = "cryptography"
+
+[[package]]
+description = "Test vectors for the cryptography package."
+conda = "cryptography-vectors"
+pypi = "cryptography_vectors"
+
+[[package]]
+description = "A suite of command-line tools for working with CSV, the king of tabular file formats."
+conda = "csvkit"
+pypi = "csvkit"
+
+[[package]]
+description = "Low-level library to perform the matrix building step in CVXPY"
+conda = "cvxcanon"
+pypi = "CVXcanon"
+
+[[package]]
+description = "Python interface to Oracle"
+conda = "cx_oracle"
+pypi = "cx_Oracle"
+
+[[package]]
+description = "Manage calls to calloc/free through Cython"
+conda = "cymem"
+pypi = "cymem"
+
+[[package]]
+description = "The Cython compiler for writing C extensions for the Python language"
+conda = "cython"
+pypi = "Cython"
+
+[[package]]
+description = "Cython implementation of Toolz. High performance functional utilities."
+conda = "cytoolz"
+pypi = "cytoolz"
+
+[[package]]
+description = "Allows using distutils2-like setup.cfg files for a package's metadata with a distribute/setuptools setup.py"
+conda = "d2to1"
+pypi = "d2to1"
+
+[[package]]
+description = "Parallel Python with task scheduling"
+conda = "dask-core"
+pypi = "dask"
+
+[[package]]
+description = "Generalized Linear Models in Dask"
+conda = "dask-glm"
+pypi = "dask-glm"
+
+[[package]]
+description = "Distributed and parallel machine learning using dask."
+conda = "dask-ml"
+pypi = "dask-ml"
+
+[[package]]
+description = "Tools for doing hyperparameter search with Scikit-Learn and Dask"
+conda = "dask-searchcv"
+pypi = "dask-searchcv"
+
+[[package]]
+description = "Data visualization toolchain based on aggregating into a grid"
+conda = "datashader"
+pypi = "datashader"
+
+[[package]]
+description = "Pure python package for reading/writing dBase, FoxPro, and Visual FoxPro .dbf files (including memos)"
+conda = "dbf"
+pypi = "dbf"
+
+[[package]]
+description = "read data from dbf files"
+conda = "dbfread"
+pypi = "dbfread"
+
+[[package]]
+description = "Better living through Python with decorators."
+conda = "decorator"
+pypi = "decorator"
+
+[[package]]
+description = "XML bomb protection for Python stdlib modules"
+conda = "defusedxml"
+pypi = "defusedxml"
+
+[[package]]
+description = "Use geometric objects as matplotlib paths and patches."
+conda = "descartes"
+pypi = "descartes"
+
+[[package]]
+description = "Serialize all of python (almost)"
+conda = "dill"
+pypi = "dill"
+
+[[package]]
+description = "Distribution utilities"
+conda = "distlib"
+pypi = "distlib"
+
+[[package]]
+description = "Distributed computing with Dask"
+conda = "distributed"
+pypi = "distributed"
+
+[[package]]
+description = "A high-level Python Web framework that encourages rapid development and clean, pragmatic design."
+conda = "django"
+pypi = "Django"
+
+[[package]]
+description = "A DNS toolkit for Python"
+conda = "dnspython"
+pypi = "dnspython"
+
+[[package]]
+description = "Pythonic argument parser, that will make you smile"
+conda = "docopt"
+pypi = "docopt"
+
+[[package]]
+description = "Docutils -- Python Documentation Utilities"
+conda = "docutils"
+pypi = "docutils"
+
+[[package]]
+description = "doit - Automation Tool"
+conda = "doit"
+pypi = "doit"
+
+[[package]]
+description = "Python wrapper around the C DRMAA library"
+conda = "drmaa"
+pypi = "drmaa"
+
+[[package]]
+description = "Official Dropbox API Client"
+conda = "dropbox"
+pypi = "dropbox"
+
+[[package]]
+description = "ECDSA cryptographic signature library (pure Python)"
+conda = "ecdsa"
+pypi = "ecdsa"
+
+[[package]]
+description = "Embedded Conic Solver (ECOS)"
+conda = "ecos"
+pypi = "ecos"
+
+[[package]]
+description = "Async backend for elasticsearch-py"
+conda = "elasticsearch-async"
+pypi = "elasticsearch-async"
+
+[[package]]
+description = "Higher-level Python client for Elasticsearch"
+conda = "elasticsearch-dsl"
+pypi = "elasticsearch-dsl"
+
+[[package]]
+description = "Python client for Elasticsearch"
+conda = "elasticsearch"
+pypi = "elasticsearch"
+
+[[package]]
+description = "Declarative DSL for building rich user interfaces in Python"
+conda = "enaml"
+pypi = "enaml"
+
+[[package]]
+description = "Discover and load entry points from installed packages."
+conda = "entrypoints"
+pypi = "entrypoints"
+
+[[package]]
+description = "Python 3.4 Enum backported to 3.3, 3.2, 3.1, 2.7, 2.6, 2.5, and 2.4"
+conda = "enum34"
+pypi = "enum34"
+
+[[package]]
+description = "Extensible application framework"
+conda = "envisage"
+pypi = "envisage"
+
+[[package]]
+description = "Basic astronomical computations for Python"
+conda = "ephem"
+pypi = "ephem"
+
+[[package]]
+description = "An implementation of lxml.xmlfile for the standard library"
+conda = "et_xmlfile"
+pypi = "et_xmlfile"
+
+[[package]]
+description = "distributed Python deployment and communication"
+conda = "execnet"
+pypi = "execnet"
+
+[[package]]
+description = "Fabric is a simple, Pythonic tool for remote execution and deployment (py2.7/py3.4+ compatible fork)."
+conda = "fabric3"
+pypi = "Fabric3"
+
+[[package]]
+description = "Fabric is a simple, Pythonic tool for remote execution and deployment."
+conda = "fabric"
+pypi = "fabric"
+
+[[package]]
+description = "A versatile test fixtures replacement based on thoughtbot's factory_girl for Ruby."
+conda = "factory_boy"
+pypi = "factory_boy"
+
+[[package]]
+description = "Faker is a Python package that generates fake data for you."
+conda = "faker"
+pypi = "Faker"
+
+[[package]]
+description = "C implementation of Python 3 lru_cache"
+conda = "fastcache"
+pypi = "fastcache"
+
+[[package]]
+description = "Fast 1D and 2D histogram functions in Python"
+conda = "fast-histogram"
+pypi = "fast-histogram"
+
+[[package]]
+description = "Python interface to the parquet format"
+conda = "fastparquet"
+pypi = "fastparquet"
+
+[[package]]
+description = "Fast, re-entrant optimistic lock implemented in Cython"
+conda = "fastrlock"
+pypi = "fastrlock"
+
+[[package]]
+description = "Display the Python traceback on a crash"
+conda = "faulthandler"
+pypi = "faulthandler"
+
+[[package]]
+description = "A platform independent file lock."
+conda = "filelock"
+pypi = "filelock"
+
+[[package]]
+description = "Your Tool For Style Guide Enforcement"
+conda = "flake8"
+pypi = "flake8"
+
+[[package]]
+description = "A flake8 and Pylama plugin that checks the ordering of your imports."
+conda = "flake8-import-order"
+pypi = "flake8-import-order"
+
+[[package]]
+description = "Provides some compatibility helpers for Flake8 plugins that intend to support Flake8 2.x and 3.x simultaneously."
+conda = "flake8-polyfill"
+pypi = "flake8-polyfill"
+
+[[package]]
+description = "Plugin for nose or py.test that automatically reruns flaky tests."
+conda = "flaky"
+pypi = "flaky"
+
+[[package]]
+description = "A Flask extension adding a decorator for CORS support"
+conda = "flask-cors"
+pypi = "Flask-Cors"
+
+[[package]]
+description = "A microframework based on Werkzeug, Jinja2 and good intentions."
+conda = "flask"
+pypi = "Flask"
+
+[[package]]
+description = "User session management for Flask"
+conda = "flask-login"
+pypi = "Flask-Login"
+
+[[package]]
+description = "Socket.IO integration for Flask applications"
+conda = "flask-socketio"
+pypi = "Flask-SocketIO"
+
+[[package]]
+description = "Simplified packaging of Python modules"
+conda = "flit"
+pypi = "flit"
+
+[[package]]
+description = "Fixes some problems with Unicode text after the fact"
+conda = "ftfy"
+pypi = "ftfy"
+
+[[package]]
+description = "Python function signatures from PEP362 for Python 2.6, 2.7 and 3.2+."
+conda = "funcsigs"
+pypi = "funcsigs"
+
+[[package]]
+description = "Backport of the functools module from Python 3.2.3 for use on 2.7 and PyPy."
+conda = "functools32"
+pypi = "functools32"
+
+[[package]]
+description = "URL manipulation made simple."
+conda = "furl"
+pypi = "furl"
+
+[[package]]
+description = "Clean single-source support for Python 3 and 2"
+conda = "future"
+pypi = "future"
+
+[[package]]
+description = "Backport of the concurrent.futures package from Python 3.2"
+conda = "futures"
+pypi = "futures"
+
+[[package]]
+description = "Python AST that abstracts the underlying Python version"
+conda = "gast"
+pypi = "gast"
+
+[[package]]
+description = "Topic Modelling for Humans"
+conda = "gensim"
+pypi = "gensim"
+
+[[package]]
+description = "GenSON is a powerful, user-friendly JSON Schema generator."
+conda = "genson"
+pypi = "genson"
+
+[[package]]
+description = "GeoViews is a Python library that makes it easy to explore and visualize geographical, meteorological, and oceanographic datasets, such as those used in weather, climate, and remote sensing research."
+conda = "geoviews-core"
+pypi = "geoviews"
+
+[[package]]
+description = "Coroutine-based network library"
+conda = "gevent"
+pypi = "gevent"
+
+[[package]]
+description = "A pure-Python git object database"
+conda = "gitdb2"
+pypi = "gitdb2"
+
+[[package]]
+description = "Multi-dimensional linked data exploration"
+conda = "glue-core"
+pypi = "glue-core"
+
+[[package]]
+description = "3D viewers for Glue"
+conda = "glue-vispy-viewers"
+pypi = "glue-vispy-viewers"
+
+[[package]]
+description = "Multi-dimensional linked data exploration"
+conda = "glueviz"
+pypi = "glueviz"
+
+[[package]]
+description = "GMP/MPIR, MPFR, and MPC interface to Python 2.6+ and 3.x"
+conda = "gmpy2"
+pypi = "gmpy2"
+
+[[package]]
+description = "Lightweight in-process concurrent programming"
+conda = "greenlet"
+pypi = "greenlet"
+
+[[package]]
+description = "Map Python functions onto a cluster using a grid engine"
+conda = "gridmap"
+pypi = "gridmap"
+
+[[package]]
+description = "Enhanced grep-like tool"
+conda = "grin"
+pypi = "grin"
+
+[[package]]
+description = "HTTP/2-based RPC framework"
+conda = "grpcio"
+pypi = "grpcio"
+
+[[package]]
+description = "WSGI HTTP Server for UNIX"
+conda = "gunicorn"
+pypi = "gunicorn"
+
+[[package]]
+description = "HTTP/2 State-Machine based protocol implementation"
+conda = "h2"
+pypi = "h2"
+
+[[package]]
+description = "Python wrapper for libhdfs3"
+conda = "hdfs3"
+pypi = "hdfs3"
+
+[[package]]
+description = "Project with useful classes/methods for all projects created by the HDInsight team at Microsoft around Jupyter"
+conda = "hdijupyterutils"
+pypi = "hdijupyterutils"
+
+[[package]]
+description = "Stop plotting your data - annotate your data and let it visualize itself."
+conda = "holoviews"
+pypi = "holoviews"
+
+[[package]]
+description = "HTTP/2 Header Encoding for Python"
+conda = "hpack"
+pypi = "hpack"
+
+[[package]]
+description = "HTML parser based on the WHATWG HTML specification"
+conda = "html5lib"
+pypi = "html5lib"
+
+[[package]]
+description = "HTTP client mocking tool for Python"
+conda = "httpretty"
+pypi = "httpretty"
+
+[[package]]
+description = "Human friendly output for text interfaces using Python."
+conda = "humanfriendly"
+pypi = "humanfriendly"
+
+[[package]]
+description = "Integrated process monitor for developing and reloading daemons."
+conda = "hupper"
+pypi = "hupper"
+
+[[package]]
+description = "Pure-Python HTTP/2 framing "
+conda = "hyperframe"
+pypi = "hyperframe"
+
+[[package]]
+description = "Immutable, Pythonic, correct URLs."
+conda = "hyperlink"
+pypi = "hyperlink"
+
+[[package]]
+description = "Productivity-centric Python Big Data Framework"
+conda = "ibis-framework"
+pypi = "ibis-framework"
+
+[[package]]
+description = "Internationalized Domain Names in Applications (IDNA)."
+conda = "idna"
+pypi = "idna"
+
+[[package]]
+description = "Patch ssl.match_hostname for Unicode(idna) domains support"
+conda = "idna_ssl"
+pypi = "idna-ssl"
+
+[[package]]
+description = "a Python library for reading and writing image data"
+conda = "imageio"
+pypi = "imageio"
+
+[[package]]
+description = "Getting image size from png/jpeg/jpeg2000/gif file"
+conda = "imagesize"
+pypi = "imagesize"
+
+[[package]]
+description = "Interactive Minimization Tools based on MINUIT"
+conda = "iminuit"
+pypi = "iminuit"
+
+[[package]]
+description = "Python client for the Impala distributed query engine"
+conda = "impyla"
+pypi = "impyla"
+
+[[package]]
+description = "A library that versions your Python projects"
+conda = "incremental"
+pypi = "incremental"
+
+[[package]]
+description = "All-in-one infinity value for Python. Can be compared to any object."
+conda = "infinity"
+pypi = "infinity"
+
+[[package]]
+description = "A port of Ruby on Rails inflector to Python"
+conda = "inflection"
+pypi = "inflection"
+
+[[package]]
+description = "Python tools for handling intervals (ranges of comparable objects)."
+conda = "intervals"
+pypi = "intervals"
+
+[[package]]
+description = "Pythonic task execution"
+conda = "invoke"
+pypi = "invoke"
+
+[[package]]
+description = "IPv4/IPv6 manipulation library"
+conda = "ipaddress"
+pypi = "ipaddress"
+
+[[package]]
+description = "Google's Python IP address manipulation library"
+conda = "ipaddr"
+pypi = "ipaddr"
+
+[[package]]
+description = "IPython Kernel for Jupyter"
+conda = "ipykernel"
+pypi = "ipykernel"
+
+[[package]]
+description = "Interactive Parallel Computing with IPython"
+conda = "ipyparallel"
+pypi = "ipyparallel"
+
+[[package]]
+description = "IPython: Productive Interactive Computing"
+conda = "ipython"
+pypi = "ipython"
+
+[[package]]
+description = "IPython: Productive Interactive Computing"
+conda = "ipython"
+pypi = "ipython"
+
+[[package]]
+description = "vestigial utilities from IPython"
+conda = "ipython_genutils"
+pypi = "ipython_genutils"
+
+[[package]]
+description = "Jupyter Interactive Widgets"
+conda = "ipywidgets"
+pypi = "ipywidgets"
+
+[[package]]
+description = "Simple module to parse ISO 8601 dates"
+conda = "iso8601"
+pypi = "iso8601"
+
+[[package]]
+description = "An ISO 8601 date/time/duration parser and formatter."
+conda = "isodate"
+pypi = "isodate"
+
+[[package]]
+description = "A Python utility / library to sort Python imports."
+conda = "isort"
+pypi = "isort"
+
+[[package]]
+description = "Various helpers to pass trusted data to untrusted environments."
+conda = "itsdangerous"
+pypi = "itsdangerous"
+
+[[package]]
+description = "jaraco.classes"
+conda = "jaraco.classes"
+pypi = "jaraco.classes"
+
+[[package]]
+description = "Julian dates from proleptic Gregorian and Julian calendars."
+conda = "jdcal"
+pypi = "jdcal"
+
+[[package]]
+description = "An autocompletion tool for Python that can be used for text editors."
+conda = "jedi"
+pypi = "jedi"
+
+[[package]]
+description = "Pure Python DBus interface"
+conda = "jeepney"
+pypi = "jeepney"
+
+[[package]]
+description = "An easy to use stand-alone template engine written in pure python."
+conda = "jinja2"
+pypi = "Jinja2"
+
+[[package]]
+description = "Query language for JSON"
+conda = "jmespath"
+pypi = "jmespath"
+
+[[package]]
+description = "JSON with datetime support"
+conda = "jsondate"
+pypi = "jsondate"
+
+[[package]]
+description = "An implementation of JSON Schema validation for Python"
+conda = "jsonschema"
+pypi = "jsonschema"
+
+[[package]]
+description = "Jupyter protocol implementation and client libraries"
+conda = "jupyter_client"
+pypi = "jupyter_client"
+
+[[package]]
+description = "Jupyter terminal console"
+conda = "jupyter_console"
+pypi = "jupyter_console"
+
+[[package]]
+description = "Core common functionality of Jupyter projects."
+conda = "jupyter_core"
+pypi = "jupyter_core"
+
+[[package]]
+description = "Jupyter metapackage. Install all the Jupyter components in one go."
+conda = "jupyter"
+pypi = "jupyter"
+
+[[package]]
+description = "An extensible environment for interactive and reproducible computing, based on the Jupyter Notebook and Architecture. Currently in beta.\n"
+conda = "jupyterlab"
+pypi = "jupyterlab"
+
+[[package]]
+description = "A Launcher for JupyterLab based applications."
+conda = "jupyterlab_launcher"
+pypi = "jupyterlab_launcher"
+
+[[package]]
+description = "Deep Learning Library for Theano and TensorFlow"
+conda = "keras-base"
+pypi = "Keras"
+
+[[package]]
+description = "Deep Learning Library for Theano and TensorFlow"
+conda = "keras"
+pypi = "Keras"
+
+[[package]]
+description = "Deep Learning Library for Theano and TensorFlow"
+conda = "keras-gpu"
+pypi = "Keras"
+
+[[package]]
+description = "Alternate keyring backend implementations for use with the keyring package."
+conda = "keyrings.alt"
+pypi = "keyrings.alt"
+
+[[package]]
+description = "Python interface YARN"
+conda = "knit"
+pypi = "knit"
+
+[[package]]
+description = "A fast and thorough lazy object proxy."
+conda = "lazy-object-proxy"
+pypi = "lazy-object-proxy"
+
+[[package]]
+description = "A strictly RFC 4510 conforming LDAP V3 pure Python client library"
+conda = "ldap3"
+pypi = "ldap3"
+
+[[package]]
+description = "Python charting for 80% of humans."
+conda = "leather"
+pypi = "leather"
+
+[[package]]
+description = "Backport of the linecache module"
+conda = "linecache2"
+pypi = "linecache2"
+
+[[package]]
+description = "Line-by-line profiling for Python"
+conda = "line_profiler"
+pypi = "line_profiler"
+
+[[package]]
+description = "File-based locks for Python for Linux and Windows"
+conda = "locket"
+pypi = "locket"
+
+[[package]]
+description = "Platform-independent file locking module"
+conda = "lockfile"
+pypi = "lockfile"
+
+[[package]]
+description = "collection of low-level Python packages and modules used by Logilab projects"
+conda = "logilab-common"
+pypi = "logilab-common"
+
+[[package]]
+description = "Pythonic binding for the C libraries libxml2 and libxslt."
+conda = "lxml"
+pypi = "lxml"
+
+[[package]]
+description = "A super-fast templating language that borrows the best ideas from the existing templating languages."
+conda = "mako"
+pypi = "Mako"
+
+[[package]]
+description = "fast and complete Python implementation of Markdown"
+conda = "markdown2"
+pypi = "markdown2"
+
+[[package]]
+description = "Python implementation of Markdown."
+conda = "markdown"
+pypi = "Markdown"
+
+[[package]]
+description = "A Python module that implements the jinja2.Markup string"
+conda = "markupsafe"
+pypi = "MarkupSafe"
+
+[[package]]
+description = "McCabe complexity checker for Python"
+conda = "mccabe"
+pypi = "mccabe"
+
+[[package]]
+description = "A module for monitoring memory usage of a python program"
+conda = "memory_profiler"
+pypi = "memory_profiler"
+
+[[package]]
+description = "The Meson Build System"
+conda = "meson"
+pypi = "meson"
+
+[[package]]
+description = "Metakernel for Jupyter."
+conda = "metakernel"
+pypi = "metakernel"
+
+[[package]]
+description = "The fastest markdown parser in pure Python."
+conda = "mistune"
+pypi = "mistune"
+
+[[package]]
+description = "A library for testing in Python."
+conda = "mock"
+pypi = "mock"
+
+[[package]]
+description = "More routines for operating on iterables, beyond itertools"
+conda = "more-itertools"
+pypi = "more-itertools"
+
+[[package]]
+description = "Library for unsupervised and semi-supervised morphological segmentation"
+conda = "morfessor"
+pypi = "Morfessor"
+
+[[package]]
+description = "D3 Viewer for Matplotlib."
+conda = "mpld3"
+pypi = "mpld3"
+
+[[package]]
+description = "Matplotlib helpers to make density scatter plots"
+conda = "mpl-scatter-density"
+pypi = "mpl-scatter-density"
+
+[[package]]
+description = "Python library for arbitrary-precision floating-point arithmetic"
+conda = "mpmath"
+pypi = "mpmath"
+
+[[package]]
+description = "Numpy data serialization using msgpack"
+conda = "msgpack-numpy"
+pypi = "msgpack-numpy"
+
+[[package]]
+description = "MessagePack (de)serializer."
+conda = "msgpack-python"
+pypi = "msgpack-python"
+
+[[package]]
+description = "multidict implementation"
+conda = "multidict"
+pypi = "multidict"
+
+[[package]]
+description = "Multiple dispatch in Python"
+conda = "multipledispatch"
+pypi = "multipledispatch"
+
+[[package]]
+description = "A dot-accessible dictionary (a la JavaScript objects)."
+conda = "munch"
+pypi = "munch"
+
+[[package]]
+description = "Cython bindings for MurmurHash2"
+conda = "murmurhash"
+pypi = "murmurhash"
+
+[[package]]
+description = "Experimental type system extensions for programs checked with the mypy typechecker."
+conda = "mypy_extensions"
+pypi = "mypy_extensions"
+
+[[package]]
+description = "Optional static typing for Python"
+conda = "mypy"
+pypi = "mypy"
+
+[[package]]
+description = "Python interface to MySQL"
+conda = "mysqlclient"
+pypi = "mysqlclient"
+
+[[package]]
+description = "Sort lists naturally"
+conda = "natsort"
+pypi = "natsort"
+
+[[package]]
+description = "Converting Jupyter Notebooks"
+conda = "nbconvert"
+pypi = "nbconvert"
+
+[[package]]
+description = "The reference implementation of the Jupyter Notebook format"
+conda = "nbformat"
+pypi = "nbformat"
+
+[[package]]
+description = "Jupyter server extension to proxy web services"
+conda = "nbserverproxy"
+pypi = "nbserverproxy"
+
+[[package]]
+description = "Basic notebook checks. Do they run? Do they contain lint?"
+conda = "nbsmoke"
+pypi = "nbsmoke"
+
+[[package]]
+description = "Provides enhanced HTTPS support for httplib and urllib2 using PyOpenSSL."
+conda = "ndg-httpsclient"
+pypi = "ndg-httpsclient"
+
+[[package]]
+description = "Nanosecond resolution temporal types"
+conda = "neotime"
+pypi = "neotime"
+
+[[package]]
+description = "Python package for creating and manipulating complex networks"
+conda = "networkx"
+pypi = "networkx"
+
+[[package]]
+description = "Python package for creating and manipulating complex networks"
+conda = "networkx"
+pypi = "networkx"
+
+[[package]]
+description = "Build Python programs to work with human language data"
+conda = "nltk"
+pypi = "nltk"
+
+[[package]]
+description = "Nose extends unittest to make testing easier"
+conda = "nose"
+pypi = "nose"
+
+[[package]]
+description = "Parameterized testing with any Python test framework."
+conda = "nose-parameterized"
+pypi = "nose-parameterized"
+
+[[package]]
+description = "A web-based notebook environment for interactive computing"
+conda = "notebook"
+pypi = "notebook"
+
+[[package]]
+description = "Array processing for numbers, strings, records, and objects."
+conda = "numpy"
+pypi = "numpy"
+
+[[package]]
+description = "Sphinx extension to support docstrings in Numpy format"
+conda = "numpydoc"
+pypi = "numpydoc"
+
+[[package]]
+description = "A generic, spec-compliant, thorough implementation of the OAuth request-signing logic"
+conda = "oauthlib"
+pypi = "oauthlib"
+
+[[package]]
+description = "parse, read and write Microsoft OLE2 files"
+conda = "olefile"
+pypi = "olefile"
+
+[[package]]
+description = "A Python library to read/write Excel 2010 xlsx/xlsm files"
+conda = "openpyxl"
+pypi = "openpyxl"
+
+[[package]]
+description = "OpenTracing API for Python."
+conda = "opentracing"
+pypi = "opentracing"
+
+[[package]]
+description = "Tracing Instrumentation using OpenTracing API (http://opentracing.io)"
+conda = "opentracing_instrumentation"
+pypi = "opentracing_instrumentation"
+
+[[package]]
+description = "Ordered Multivalue Dictionary - omdict."
+conda = "orderedmultidict"
+pypi = "orderedmultidict"
+
+[[package]]
+description = "OGC Web Service utility library."
+conda = "owslib"
+pypi = "OWSLib"
+
+[[package]]
+description = "Core utilities for Python packages"
+conda = "packaging"
+pypi = "packaging"
+
+[[package]]
+description = "Color palettes for Python."
+conda = "palettable"
+pypi = "palettable"
+
+[[package]]
+description = "Up to date remote data access for pandas, works for multiple versions of pandas"
+conda = "pandas-datareader"
+pypi = "pandas-datareader"
+
+[[package]]
+description = "Generate profile report for pandas DataFrame"
+conda = "pandas-profiling"
+pypi = "pandas-profiling"
+
+[[package]]
+description = "A python module for writing pandoc filters"
+conda = "pandocfilters"
+pypi = "pandocfilters"
+
+[[package]]
+description = "Parameterized testing with any Python test framework"
+conda = "parameterized"
+pypi = "parameterized"
+
+[[package]]
+description = "Param: Make your Python code clearer and more reliable by declaring Parameters"
+conda = "param"
+pypi = "param"
+
+[[package]]
+description = "SSH2 protocol library"
+conda = "paramiko"
+pypi = "paramiko"
+
+[[package]]
+description = "Parse human-readable date/time text."
+conda = "parsedatetime"
+pypi = "parsedatetime"
+
+[[package]]
+description = "library to extract data from HTML and XML using XPath and CSS selectors"
+conda = "parsel"
+pypi = "parsel"
+
+[[package]]
+description = "A Python Parser"
+conda = "parso"
+pypi = "parso"
+
+[[package]]
+description = "Data structure for on-disk shuffle operations"
+conda = "partd"
+pypi = "partd"
+
+[[package]]
+description = "comprehensive password hashing framework supporting over 30 schemes"
+conda = "passlib"
+pypi = "passlib"
+
+[[package]]
+description = "Load, configure, and compose WSGI applications and servers"
+conda = "pastedeploy"
+pypi = "PasteDeploy"
+
+[[package]]
+description = "Fork of pathlib aiming to support the full stdlib Python API."
+conda = "pathlib2"
+pypi = "pathlib2"
+
+[[package]]
+description = "Object-oriented filesystem paths"
+conda = "pathlib"
+pypi = "pathlib"
+
+[[package]]
+description = "A module wrapper for os.path"
+conda = "path.py"
+pypi = "path.py"
+
+[[package]]
+description = "Describing statistical models in Python using symbolic formulas"
+conda = "patsy"
+pypi = "patsy"
+
+[[package]]
+description = "Python Build Reasonableness"
+conda = "pbr"
+pypi = "pbr"
+
+[[package]]
+description = "Python style guide checker"
+conda = "pep8"
+pypi = "pep8"
+
+[[package]]
+description = "Plug-in for flake 8 to check the PEP-8 naming conventions"
+conda = "pep8-naming"
+pypi = "pep8-naming"
+
+[[package]]
+description = "Python module to generate and modify perf"
+conda = "perf"
+pypi = "perf"
+
+[[package]]
+description = "Python benchmark suite"
+conda = "performance"
+pypi = "performance"
+
+[[package]]
+description = "Translucent persistent objects"
+conda = "persistent"
+pypi = "persistent"
+
+[[package]]
+description = "A Python package for extracting, transforming and loading tables of data."
+conda = "petl"
+pypi = "petl"
+
+[[package]]
+description = "Pexpect makes Python a better tool for controlling other applications."
+conda = "pexpect"
+pypi = "pexpect"
+
+[[package]]
+description = "Python version of Google's common library for parsing, formatting, storing and validating international phone numbers."
+conda = "phonenumbers"
+pypi = "phonenumbers"
+
+[[package]]
+description = "Tiny 'shelve'-like database with concurrency support"
+conda = "pickleshare"
+pypi = "pickleshare"
+
+[[package]]
+description = "Pillow is the friendly PIL fork by Alex Clark and Contributors."
+conda = "pillow"
+pypi = "Pillow"
+
+[[package]]
+description = "PyPA recommended tool for installing Python packages"
+conda = "pip"
+pypi = "pip"
+
+[[package]]
+description = "PivotTable.js integration for Jupyter/IPython Notebook"
+conda = "pivottablejs"
+pypi = "pivottablejs"
+
+[[package]]
+description = "Query metadatdata from sdists / bdists / installed packages."
+conda = "pkginfo"
+pypi = "pkginfo"
+
+[[package]]
+description = "The smartest command line arguments parser in the world"
+conda = "plac"
+pypi = "plac"
+
+[[package]]
+description = "A loader interface around multiple config file formats."
+conda = "plaster"
+pypi = "plaster"
+
+[[package]]
+description = "A loader implementing the PasteDeploy syntax to be used by plaster."
+conda = "plaster_pastedeploy"
+pypi = "plaster_pastedeploy"
+
+[[package]]
+description = "An interactive, browser-based graphing library for Python"
+conda = "plotly"
+pypi = "plotly"
+
+[[package]]
+description = "Plugin registration and hook calling for Python"
+conda = "pluggy"
+pypi = "pluggy"
+
+[[package]]
+description = "TCP port monitoring utilities"
+conda = "portend"
+pypi = "portend"
+
+[[package]]
+description = "A library to choose unique available network ports."
+conda = "portpicker"
+pypi = "portpicker"
+
+[[package]]
+description = "POSIX IPC for Python"
+conda = "posix_ipc"
+pypi = "posix_ipc"
+
+[[package]]
+description = "A library for stubbing in Python"
+conda = "pretend"
+pypi = "pretend"
+
+[[package]]
+description = "A pure-Python implementation of the HTTP/2 priority tree"
+conda = "priority"
+pypi = "priority"
+
+[[package]]
+description = "A Python Progressbar library to provide visual (yet text based) progress to long running operations."
+conda = "progressbar2"
+pypi = "progressbar2"
+
+[[package]]
+description = "Easy progress reporting for Python"
+conda = "progress"
+pypi = "progress"
+
+[[package]]
+description = "Library for building powerful interactive command lines in Python"
+conda = "prompt_toolkit"
+pypi = "prompt_toolkit"
+
+[[package]]
+description = "Library for building powerful interactive command lines in Python"
+conda = "prompt_toolkit"
+pypi = "prompt_toolkit"
+
+[[package]]
+description = "A cross-platform process and system utilities module for Python"
+conda = "psutil"
+pypi = "psutil"
+
+[[package]]
+description = "PostgreSQL database adapter for Python"
+conda = "psycopg2"
+pypi = "psycopg2"
+
+[[package]]
+description = "Run a subprocess in a pseudo terminal"
+conda = "ptyprocess"
+pypi = "ptyprocess"
+
+[[package]]
+description = "Pure Python client SASL implementation"
+conda = "pure-sasl"
+pypi = "pure-sasl"
+
+[[package]]
+description = "Enables Python programs to dynamically access arbitrary Java objects"
+conda = "py4j"
+pypi = "py4j"
+
+[[package]]
+description = "Algebraic Multigrid Solvers in Python"
+conda = "pyamg"
+pypi = "pyamg"
+
+[[package]]
+description = "ASN.1 types and codecs"
+conda = "pyasn1"
+pypi = "pyasn1"
+
+[[package]]
+description = "A collection of ASN.1-based protocols modules."
+conda = "pyasn1-modules"
+pypi = "pyasn1-modules"
+
+[[package]]
+description = "Python style guide checker"
+conda = "pycodestyle"
+pypi = "pycodestyle"
+
+[[package]]
+description = "Complete C99 parser in pure Python"
+conda = "pycparser"
+pypi = "pycparser"
+
+[[package]]
+description = "A module for getting CPU info with Python 2 & 3"
+conda = "py-cpuinfo"
+pypi = "py-cpuinfo"
+
+[[package]]
+description = "Cryptographic library for Python"
+conda = "pycryptodomex"
+pypi = "pycryptodomex"
+
+[[package]]
+description = "Cryptographic modules for Python."
+conda = "pycrypto"
+pypi = "pycrypto"
+
+[[package]]
+description = "python package common tasks for users (e.g. copy examples, fetch data, ...)"
+conda = "pyct"
+pypi = "pyct"
+
+[[package]]
+description = "A Python Interface To The cURL library"
+conda = "pycurl"
+pypi = "pycurl"
+
+[[package]]
+description = "Multi-producer-multi-consumer signal dispatching mechanism"
+conda = "pydispatcher"
+pypi = "PyDispatcher"
+
+[[package]]
+description = "Python interface to Graphviz's Dot"
+conda = "pydot"
+pypi = "pydot"
+
+[[package]]
+description = "A Python wrapper for the Earth Mover's Distance."
+conda = "pyemd"
+pypi = "pyemd"
+
+[[package]]
+description = "Traits-capable windowing framework"
+conda = "pyface"
+pypi = "pyface"
+
+[[package]]
+description = "library with cross-python path, ini-parsing, io, code, log facilities"
+conda = "py"
+pypi = "py"
+
+[[package]]
+description = "Pyflakes analyzes programs and detects various errors."
+conda = "pyflakes"
+pypi = "pyflakes"
+
+[[package]]
+description = "Pyflakes analyzes programs and detects various errors."
+conda = "pyflakes"
+pypi = "pyflakes"
+
+[[package]]
+description = "Generic syntax highlighting package"
+conda = "pygments"
+pypi = "Pygments"
+
+[[package]]
+description = "Python interface to Hive"
+conda = "pyhive"
+pypi = "PyHive"
+
+[[package]]
+description = "Monitoring filesystems events with inotify on Linux."
+conda = "pyinotify"
+pypi = "pyinotify"
+
+[[package]]
+description = "JSON Web Token implementation in Python"
+conda = "pyjwt"
+pypi = "PyJWT"
+
+[[package]]
+description = "high-level interface to Kerberos"
+conda = "pykerberos"
+pypi = "pykerberos"
+
+[[package]]
+description = "python code static checker"
+conda = "pylint"
+pypi = "pylint"
+
+[[package]]
+description = "Pure Python MySQL Driver"
+conda = "pymysql"
+pypi = "PyMySQL"
+
+[[package]]
+description = "PyNaCl is a Python binding to the Networking and Cryptography library, a crypto library with the stated goal of improving usability, security and speed."
+conda = "pynacl"
+pypi = "PyNaCl"
+
+[[package]]
+description = "DB API Module for ODBC"
+conda = "pyodbc"
+pypi = "pyodbc"
+
+[[package]]
+description = "Standard OpenGL bindings for Python"
+conda = "pyopengl"
+pypi = "PyOpenGL"
+
+[[package]]
+description = "Python wrapper module around the OpenSSL library"
+conda = "pyopenssl"
+pypi = "pyOpenSSL"
+
+[[package]]
+description = "Create and execute simple grammars"
+conda = "pyparsing"
+pypi = "pyparsing"
+
+[[package]]
+description = "Scientific Graphics and GUI Library for Python"
+conda = "pyqtgraph"
+pypi = "pyqtgraph"
+
+[[package]]
+description = "A jquery-like library for python"
+conda = "pyquery"
+pypi = "pyquery"
+
+[[package]]
+description = "interactive HTML debugger for Pyramid application development"
+conda = "pyramid_debugtoolbar"
+pypi = "pyramid_debugtoolbar"
+
+[[package]]
+description = "The Pyramid Web Framework, a Pylons project"
+conda = "pyramid"
+pypi = "pyramid"
+
+[[package]]
+description = "Jinja2 template bindings for the Pyramid web framework"
+conda = "pyramid_jinja2"
+pypi = "pyramid_jinja2"
+
+[[package]]
+description = "Mako template bindings for the Pyramid web framework"
+conda = "pyramid_mako"
+pypi = "pyramid_mako"
+
+[[package]]
+description = "Allows Pyramid requests to join the active transaction"
+conda = "pyramid_tm"
+pypi = "pyramid_tm"
+
+[[package]]
+description = "Library of spatial analysis functions."
+conda = "pysal"
+pypi = "PySAL"
+
+[[package]]
+description = "htslib interface for python"
+conda = "pysam"
+pypi = "pysam"
+
+[[package]]
+description = "Python serial port access library"
+conda = "pyserial"
+pypi = "pyserial"
+
+[[package]]
+description = "Pure Python read/write support for ESRI Shapefile format."
+conda = "pyshp"
+pypi = "pyshp"
+
+[[package]]
+description = "SNMP SMI/MIB Parser"
+conda = "pysmi"
+pypi = "pysmi"
+
+[[package]]
+description = "SNMP library for Python"
+conda = "pysnmp"
+pypi = "pysnmp"
+
+[[package]]
+description = "A Python SOCKS client module. See https://github.com/Anorov/PySocks for more information."
+conda = "pysocks"
+pypi = "PySocks"
+
+[[package]]
+description = "Python interface to Stan, a package for Bayesian inference"
+conda = "pystan"
+pypi = "pystan"
+
+[[package]]
+description = "pytest plugin to help with comparing array output from tests"
+conda = "pytest-arraydiff"
+pypi = "pytest-arraydiff"
+
+[[package]]
+description = "Meta-package containing dependencies for testing Astropy"
+conda = "pytest-astropy"
+pypi = "pytest-astropy"
+
+[[package]]
+description = "Pytest support for asyncio"
+conda = "pytest-asyncio"
+pypi = "pytest-asyncio"
+
+[[package]]
+description = "pytest plugin for URL based testing"
+conda = "pytest-base-url"
+pypi = "pytest-base-url"
+
+[[package]]
+description = "A py.test fixture for benchmarking code"
+conda = "pytest-benchmark"
+pypi = "pytest-benchmark"
+
+[[package]]
+description = "Pytest plugin for measuring coverage"
+conda = "pytest-cov"
+pypi = "pytest-cov"
+
+[[package]]
+description = "Pytest plugin with advanced doctest features"
+conda = "pytest-doctestplus"
+pypi = "pytest-doctestplus"
+
+[[package]]
+description = "Simple and powerful testing with Python."
+conda = "pytest"
+pypi = "pytest"
+
+[[package]]
+description = "run tests in isolated forked subprocesses"
+conda = "pytest-forked"
+pypi = "pytest-forked"
+
+[[package]]
+description = "pytest plugin for generating HTML reports"
+conda = "pytest-html"
+pypi = "pytest-html"
+
+[[package]]
+description = "pytest plugin for test session metadata"
+conda = "pytest-metadata"
+pypi = "pytest-metadata"
+
+[[package]]
+description = "Thin-wrapper around the mock package for easier use with py.test"
+conda = "pytest-mock"
+pypi = "pytest-mock"
+
+[[package]]
+description = "Pytest plugin for detecting inadvertent open file handles"
+conda = "pytest-openfiles"
+pypi = "pytest-openfiles"
+
+[[package]]
+description = "Pytest plugin for controlling remote data access"
+conda = "pytest-remotedata"
+pypi = "pytest-remotedata"
+
+[[package]]
+description = "Invoke py.test as distutils command with dependency resolution."
+conda = "pytest-runner"
+pypi = "pytest-runner"
+
+[[package]]
+description = "pytest-selenium is a plugin for py.test that provides support for running Selenium based tests."
+conda = "pytest-selenium"
+pypi = "pytest-selenium"
+
+[[package]]
+description = "This is a plugin which will terminate tests after a certain timeout."
+conda = "pytest-timeout"
+pypi = "pytest-timeout"
+
+[[package]]
+description = "pytest plugin for providing variables to tests/fixtures"
+conda = "pytest-variables"
+pypi = "pytest-variables"
+
+[[package]]
+description = "py.test xdist plugin for distributed testing and loop-on-failing modes"
+conda = "pytest-xdist"
+pypi = "pytest-xdist"
+
+[[package]]
+description = "A Python wrapper for the extremely fast Blosc compression library"
+conda = "python-blosc"
+pypi = "blosc"
+
+[[package]]
+description = "Python binding for CRFsuite"
+conda = "python-crfsuite"
+pypi = "python-crfsuite"
+
+[[package]]
+description = "Library to implement a well-behaved Unix daemon process."
+conda = "python-daemon"
+pypi = "python-daemon"
+
+[[package]]
+description = "Extensions to the standard Python datetime module."
+conda = "python-dateutil"
+pypi = "python-dateutil"
+
+[[package]]
+description = "Programmatically open an editor, capture the result."
+conda = "python-editor"
+pypi = "python-editor"
+
+[[package]]
+description = "Engine.IO server"
+conda = "python-engineio"
+pypi = "python-engineio"
+
+[[package]]
+description = "Google Commandline Flags Module"
+conda = "python-gflags"
+pypi = "python-gflags"
+
+[[package]]
+description = "Simple Python interface for Graphviz"
+conda = "python-graphviz"
+pypi = "graphviz"
+
+[[package]]
+description = "HdfsCLI: API and command line interface for HDFS."
+conda = "python-hdfs"
+pypi = "hdfs"
+
+[[package]]
+description = "Python bindings for leveldb database library"
+conda = "python-leveldb"
+pypi = "leveldb"
+
+[[package]]
+description = "Python interface to libarchive"
+conda = "python-libarchive-c"
+pypi = "libarchive-c"
+
+[[package]]
+description = "Pure python memcached client"
+conda = "python-memcached"
+pypi = "python-memcached"
+
+[[package]]
+description = "Python wrapper around rapidjson"
+conda = "python-rapidjson"
+pypi = "python-rapidjson"
+
+[[package]]
+description = "A Python Slugify application that handles Unicode"
+conda = "python-slugify"
+pypi = "python-slugify"
+
+[[package]]
+description = "Python library for the snappy compression library from Google"
+conda = "python-snappy"
+pypi = "python-snappy"
+
+[[package]]
+description = "Socket.IO server"
+conda = "python-socketio"
+pypi = "python-socketio"
+
+[[package]]
+description = "Python Utils is a collection of small Python functions and classes which make common patterns shorter and easier."
+conda = "python-utils"
+pypi = "python-utils"
+
+[[package]]
+description = "A small Python library to parse various kinds of time expressions"
+conda = "pytimeparse"
+pypi = "pytimeparse"
+
+[[package]]
+description = "A TOML-0.4.0 parser/writer for Python."
+conda = "pytoml"
+pypi = "pytoml"
+
+[[package]]
+description = "World timezone definitions, modern and historical."
+conda = "pytz"
+pypi = "pytz"
+
+[[package]]
+description = "PyUtilib: A collection of Python utilities"
+conda = "pyutilib"
+pypi = "PyUtilib"
+
+[[package]]
+description = "Bidirectional communication for PyViz"
+conda = "pyviz_comms"
+pypi = "pyviz_comms"
+
+[[package]]
+description = "Pure Python download utility"
+conda = "pywget"
+pypi = "wget"
+
+[[package]]
+description = "Python bindings for zeromq"
+conda = "pyzmq"
+pypi = "pyzmq"
+
+[[package]]
+description = "Pandas DataFrame viewer for Jupyter Notebook"
+conda = "qgrid"
+pypi = "qgrid"
+
+[[package]]
+description = "Iconic fonts in PyQt and PySide applications"
+conda = "qtawesome"
+pypi = "qtawesome"
+
+[[package]]
+description = "Jupyter Qt console"
+conda = "qtconsole"
+pypi = "qtconsole"
+
+[[package]]
+description = "Abtraction layer for PyQt5/PyQt4/PySide"
+conda = "qtpy"
+pypi = "qtpy"
+
+[[package]]
+description = "Collection of persistent (disk-based) queues"
+conda = "queuelib"
+pypi = "queuelib"
+
+[[package]]
+description = "Interactive per-layer visualization for convents in keras"
+conda = "quiver_engine"
+pypi = "quiver_engine"
+
+[[package]]
+description = "Alternative regular expression module, to replace re."
+conda = "regex"
+pypi = "regex"
+
+[[package]]
+description = "A tiny LRU cache implementation and decorator"
+conda = "repoze.lru"
+pypi = "repoze.lru"
+
+[[package]]
+description = "Download files using requests and save them to a target path"
+conda = "requests_download"
+pypi = "requests_download"
+
+[[package]]
+description = "Python HTTP for Humans."
+conda = "requests"
+pypi = "requests"
+
+[[package]]
+description = "file transport adapter for Requests"
+conda = "requests-file"
+pypi = "requests-file"
+
+[[package]]
+description = "An FTP transport adapter for use with the Python Requests library"
+conda = "requests-ftp"
+pypi = "requests-ftp"
+
+[[package]]
+description = "Kerberos authentication handler for python-requests"
+conda = "requests-kerberos"
+pypi = "requests-kerberos"
+
+[[package]]
+description = "OAuthlib authentication support for Requests."
+conda = "requests-oauthlib"
+pypi = "requests-oauthlib"
+
+[[package]]
+description = "A utility belt for advanced users of python-requests."
+conda = "requests-toolbelt"
+pypi = "requests-toolbelt"
+
+[[package]]
+description = "utility library for mocking out the 'requests' Python library"
+conda = "responses"
+pypi = "responses"
+
+[[package]]
+description = "A python refactoring library..."
+conda = "rope"
+pypi = "rope"
+
+[[package]]
+description = "Routing Recognition and Generation Tools"
+conda = "routes"
+pypi = "Routes"
+
+[[package]]
+description = "Convenient Filesystem interface over S3"
+conda = "s3fs"
+pypi = "s3fs"
+
+[[package]]
+description = "An Amazon S3 Transfer Manager"
+conda = "s3transfer"
+pypi = "s3transfer"
+
+[[package]]
+description = "sas7bdat file reader for Python"
+conda = "sas7bdat"
+pypi = "sas7bdat"
+
+[[package]]
+description = "A Jupyter kernel for SAS"
+conda = "sas_kernel"
+pypi = "sas_kernel"
+
+[[package]]
+description = "A Python interface module to the SAS System"
+conda = "saspy"
+pypi = "saspy"
+
+[[package]]
+description = "scandir, a better directory iterator and faster os.walk()"
+conda = "scandir"
+pypi = "scandir"
+
+[[package]]
+description = "Data structures, algorithms and educational resources for bioinformatics."
+conda = "scikit-bio"
+pypi = "scikit-bio"
+
+[[package]]
+description = "Open Source next-generation build tool."
+conda = "scons"
+pypi = "scons"
+
+[[package]]
+description = "A high-level Python Screen Scraping framework"
+conda = "scrapy"
+pypi = "Scrapy"
+
+[[package]]
+description = "Statistical data visualization"
+conda = "seaborn"
+pypi = "seaborn"
+
+[[package]]
+description = "Provides a way for securely storing passwords and other secrets."
+conda = "secretstorage"
+pypi = "SecretStorage"
+
+[[package]]
+description = "Python bindings for the Selenium WebDriver for automating web browser interaction."
+conda = "selenium"
+pypi = "selenium"
+
+[[package]]
+description = "Python package to work with Semantic Versioning"
+conda = "semver"
+pypi = "semver"
+
+[[package]]
+description = "Python library to natively send files to Trash (or Recycle bin) on all platforms."
+conda = "send2trash"
+pypi = "Send2Trash"
+
+[[package]]
+description = "An utility that accesses files on a HTTP server and stores them locally for reuse"
+conda = "serverfiles"
+pypi = "serverfiles"
+
+[[package]]
+description = "Service identity verification for pyOpenSSL."
+conda = "service_identity"
+pypi = "service_identity"
+
+[[package]]
+description = "Download, build, install, upgrade, and uninstall Python packages"
+conda = "setuptools"
+pypi = "setuptools"
+
+[[package]]
+description = "The blessed package to manage your versions by scm tags."
+conda = "setuptools_scm"
+pypi = "setuptools_scm"
+
+[[package]]
+description = "setuptools_scm plugin for git archives"
+conda = "setuptools_scm_git_archive"
+pypi = "setuptools_scm_git_archive"
+
+[[package]]
+description = "Python package for manipulation and analysis of geometric objects in the Cartesian plane."
+conda = "shapely"
+pypi = "Shapely"
+
+[[package]]
+description = "Python subprocess interface"
+conda = "sh"
+pypi = "sh"
+
+[[package]]
+description = "Simple generic functions (similar to Python's own len(), pickle.dump(), etc.)"
+conda = "simplegeneric"
+pypi = "simplegeneric"
+
+[[package]]
+description = "Simple, fast, extensible JSON encoder/decoder for Python"
+conda = "simplejson"
+pypi = "simplejson"
+
+[[package]]
+description = "Transforms a function into a single-dispatch generic function"
+conda = "singledispatch"
+pypi = "singledispatch"
+
+[[package]]
+description = "Python 2 and 3 compatibility utilities"
+conda = "six"
+pypi = "six"
+
+[[package]]
+description = "Python library for efficient streaming of large files"
+conda = "smart_open"
+pypi = "smart_open"
+
+[[package]]
+description = "A pure python implementation of a sliding window memory map manager"
+conda = "smmap2"
+pypi = "smmap2"
+
+[[package]]
+description = "Pure Python HDFS client"
+conda = "snakebite"
+pypi = "snakebite"
+
+[[package]]
+description = "Web-based viewer for Python profiler output"
+conda = "snakeviz"
+pypi = "snakeviz"
+
+[[package]]
+description = "Snowball stemming library collection for Python"
+conda = "snowballstemmer"
+pypi = "snowballstemmer"
+
+[[package]]
+description = "Snuggs are s-expressions for NumPy."
+conda = "snuggs"
+pypi = "snuggs"
+
+[[package]]
+description = "Simple to use SOAP library for Python"
+conda = "soappy"
+pypi = "SOAPpy"
+
+[[package]]
+description = "Python Sorted Collections"
+conda = "sortedcollections"
+pypi = "sortedcollections"
+
+[[package]]
+description = "Python Sorted Container Types: SortedList, SortedDict, and SortedSet"
+conda = "sortedcontainers"
+pypi = "sortedcontainers"
+
+[[package]]
+description = "Industrial-strength Natural Language Processing"
+conda = "spacy"
+pypi = "spacy"
+
+[[package]]
+description = "Jupyter magics and kernels for working with remote Spark clusters"
+conda = "sparkmagic"
+pypi = "sparkmagic"
+
+[[package]]
+description = "Sphinx API for Web Apps"
+conda = "sphinxcontrib-websupport"
+pypi = "sphinxcontrib-websupport"
+
+[[package]]
+description = "Sphinx is a tool that makes it easy to create intelligent and beautiful documentation"
+conda = "sphinx"
+pypi = "Sphinx"
+
+[[package]]
+description = "ReadTheDocs.org theme for Sphinx, 2013 version."
+conda = "sphinx_rtd_theme"
+pypi = "sphinx_rtd_theme"
+
+[[package]]
+description = "Scientific PYthon Development EnviRonment"
+conda = "spyder"
+pypi = "spyder"
+
+[[package]]
+description = "Jupyter kernels for the Spyder console"
+conda = "spyder-kernels"
+pypi = "spyder-kernels"
+
+[[package]]
+description = "Jupyter kernels for the Spyder console"
+conda = "spyder-kernels"
+pypi = "spyder-kernels"
+
+[[package]]
+description = "Database Abstraction Library."
+conda = "sqlalchemy"
+pypi = "SQLAlchemy"
+
+[[package]]
+description = "Various utility functions for SQLAlchemy."
+conda = "sqlalchemy-utils"
+pypi = "SQLAlchemy-Utils"
+
+[[package]]
+description = "A non-validating SQL parser module for Python."
+conda = "sqlparse"
+pypi = "sqlparse"
+
+[[package]]
+description = "The ssl.match_hostname() function from Python 3.5"
+conda = "ssl_match_hostname"
+pypi = "backports.ssl_match_hostname"
+
+[[package]]
+description = "A Python 2.* port of 3.4 Statistics Module"
+conda = "statistics"
+pypi = "statistics"
+
+[[package]]
+description = "Statistical computations and models for use with SciPy"
+conda = "statsmodels"
+pypi = "statsmodels"
+
+[[package]]
+description = "Manage streaming data, optionally with Dask and Pandas"
+conda = "streamz"
+pypi = "streamz"
+
+[[package]]
+description = "Stripe python bindings"
+conda = "stripe"
+pypi = "stripe"
+
+[[package]]
+description = "A backport of the subprocess module from Python 3.2/3.3 for use on 2.x."
+conda = "subprocess32"
+pypi = "subprocess32"
+
+[[package]]
+description = "A Process Control System"
+conda = "supervisor"
+pypi = "supervisor"
+
+[[package]]
+description = "Python library for symbolic mathematics"
+conda = "sympy"
+pypi = "sympy"
+
+[[package]]
+description = "Pretty-print tabular data in Python, a library and a command-line utility."
+conda = "tabulate"
+pypi = "tabulate"
+
+[[package]]
+description = "Traceback serialization library."
+conda = "tblib"
+pypi = "tblib"
+
+[[package]]
+description = "Objects and routines pertaining to date and time (tempora)"
+conda = "tempora"
+pypi = "tempora"
+
+[[package]]
+description = "ANSII Color formatting for output in terminal."
+conda = "termcolor"
+pypi = "termcolor"
+
+[[package]]
+description = "Terminals served by tornado websockets"
+conda = "terminado"
+pypi = "terminado"
+
+[[package]]
+description = "A collection of helpers and mock objects for unit tests and doc tests."
+conda = "testfixtures"
+pypi = "testfixtures"
+
+[[package]]
+description = "Testpath is a collection of utilities for Python code working with files and commands."
+conda = "testpath"
+pypi = "testpath"
+
+[[package]]
+description = "Summary of the package"
+conda = "testscenarios"
+pypi = "testscenarios"
+
+[[package]]
+description = "Extensions to the Python standard library unit testing framework"
+conda = "testtools"
+pypi = "testtools"
+
+[[package]]
+description = "The most basic Text Unidecode port"
+conda = "text-unidecode"
+pypi = "text-unidecode"
+
+[[package]]
+description = "thinc: Learn super-sparse multi-class models"
+conda = "thinc"
+pypi = "thinc"
+
+[[package]]
+description = "Python bindings for the Apache Thrift RPC system"
+conda = "thrift"
+pypi = "thrift"
+
+[[package]]
+description = "Python bindings for the Apache Thrift RPC system"
+conda = "thrift"
+pypi = "thrift"
+
+[[package]]
+description = "Pure python implementation of Apache Thrift."
+conda = "thriftpy"
+pypi = "thriftpy"
+
+[[package]]
+description = "Thrift SASL module that implements TSaslClientTransport"
+conda = "thrift_sasl"
+pypi = "thrift_sasl"
+
+[[package]]
+description = "Microsoft Azure Client Libraries for Python"
+conda = "azure"
+pypi = "azure"
+
+[[package]]
+description = "Microsoft Azure Client Libraries for Python"
+conda = "azure"
+pypi = "azure"
+
+[[package]]
+description = "Convex optimization package"
+conda = "cvxopt"
+pypi = "cvxopt"
+
+[[package]]
+description = "A high-level Python Web framework that encourages rapid development and clean, pragmatic design."
+conda = "django"
+pypi = "Django"
+
+[[package]]
+description = "low-level drawing and interaction"
+conda = "enable"
+pypi = "enable"
+
+[[package]]
+description = "Fiona reads and writes spatial data files."
+conda = "fiona"
+pypi = "Fiona"
+
+[[package]]
+description = "Multidimensional data visualization across files"
+conda = "glueviz"
+pypi = "glueviz"
+
+[[package]]
+description = "Multi-dimensional linked data exploration"
+conda = "glueviz"
+pypi = "glueviz"
+
+[[package]]
+description = "Stop plotting your data - annotate your data and let it visualize itself."
+conda = "holoviews"
+pypi = "holoviews"
+
+[[package]]
+description = "SSH2 protocol library"
+conda = "paramiko"
+pypi = "paramiko"
+
+[[package]]
+description = "Python driver for MongoDB"
+conda = "pymongo"
+pypi = "pymongo"
+
+[[package]]
+description = "The Pyramid Web Framework, a Pylons project"
+conda = "pyramid"
+pypi = "pyramid"
+
+[[package]]
+description = "SNMP library for Python"
+conda = "pysnmp"
+pypi = "pysnmp"
+
+[[package]]
+description = "Rasterio reads and writes geospatial raster datasets."
+conda = "rasterio"
+pypi = "rasterio"
+
+[[package]]
+description = "Python package for manipulation and analysis of geometric objects in the Cartesian plane."
+conda = "shapely"
+pypi = "Shapely"
+
+[[package]]
+description = "Industrial-strength Natural Language Processing"
+conda = "spacy"
+pypi = "spacy"
+
+[[package]]
+description = "A functional standard library for Python."
+conda = "toolz"
+pypi = "toolz"
+
+[[package]]
+description = "A Python web framework and asynchronous networking library, originally developed at FriendFeed."
+conda = "tornado"
+pypi = "tornado"
+
+[[package]]
+description = "A Fast, Extensible Progress Meter"
+conda = "tqdm"
+pypi = "tqdm"
+
+[[package]]
+description = "Backports of the traceback module"
+conda = "traceback2"
+pypi = "traceback2"
+
+[[package]]
+description = "Configuration system for Python applications"
+conda = "traitlets"
+pypi = "traitlets"
+
+[[package]]
+description = "TraitsUI - Traits-capable windowing framework"
+conda = "traitsui"
+pypi = "traitsui"
+
+[[package]]
+description = "Transaction management for Python"
+conda = "transaction"
+pypi = "transaction"
+
+[[package]]
+description = "Utility library for i18n"
+conda = "translationstring"
+pypi = "translationstring"
+
+[[package]]
+description = "Port of the Tulip project (asyncio module, PEP 3156) on Python 2"
+conda = "trollius"
+pypi = "trollius"
+
+[[package]]
+description = "Collection of utilities for interacting with PyPI"
+conda = "twine"
+pypi = "twine"
+
+[[package]]
+description = "event-driven networking engine"
+conda = "twisted"
+pypi = "Twisted"
+
+[[package]]
+description = "Actively maintained, pure Python wrapper for the Twitter API. Supports both normal and streaming Twitter APIs"
+conda = "twython"
+pypi = "twython"
+
+[[package]]
+description = "a fork of Python 2 and 3 ast modules with type comment support"
+conda = "typed-ast"
+pypi = "typed-ast"
+
+[[package]]
+description = "Type Hints for Python - backport for Python<3.5"
+conda = "typing"
+pypi = "typing"
+
+[[package]]
+description = "tzinfo object for the local timezone"
+conda = "tzlocal"
+pypi = "tzlocal"
+
+[[package]]
+description = "Ultra fast JSON decoder and encoder written in C with Python bindings"
+conda = "ujson"
+pypi = "ujson"
+
+[[package]]
+description = "Drop-in replacement for csv module which supports unicode strings"
+conda = "unicodecsv"
+pypi = "unicodecsv"
+
+[[package]]
+description = "ASCII transliterations of Unicode text"
+conda = "unidecode"
+pypi = "Unidecode"
+
+[[package]]
+description = "The new features in unittest backported to Python 2.4+"
+conda = "unittest2"
+pypi = "unittest2"
+
+[[package]]
+description = "HTTP library with thread-safe connection pooling, file post, and more."
+conda = "urllib3"
+pypi = "urllib3"
+
+[[package]]
+description = "Ultra fast implementation of asyncio event loop on top of libuv."
+conda = "uvloop"
+pypi = "uvloop"
+
+[[package]]
+description = "The uWSGI project aims at developing a full stack for building hosting\nservices. Application servers (for various programming languages and\nprotocols), proxies, process managers and monitors are all implemented.\n"
+conda = "uwsgi"
+pypi = "uWSGI"
+
+[[package]]
+description = "The uWSGI server"
+conda = "uwsgi"
+pypi = "uwsgi"
+
+[[package]]
+description = "Take version numbers from version control."
+conda = "vcversioner"
+pypi = "33162c0a7b28a4d8c83da07bc2b12cee58c120b4a9e8bba31c41c8d35a16"
+
+[[package]]
+description = "A library for deferring decorator actions"
+conda = "venusian"
+pypi = "venusian"
+
+[[package]]
+description = "Verbose logging level for Python's logging module."
+conda = "verboselogs"
+pypi = "verboselogs"
+
+[[package]]
+description = "Virtual Python Environment builder"
+conda = "virtualenv"
+pypi = "virtualenv"
+
+[[package]]
+description = "High performance interactive 2D/3D data visualization."
+conda = "vispy"
+pypi = "vispy"
+
+[[package]]
+description = "An object oriented approach to visualization of 1D to 4D data"
+conda = "visvis"
+pypi = "visvis"
+
+[[package]]
+description = "Library of web-related functions"
+conda = "w3lib"
+pypi = "w3lib"
+
+[[package]]
+description = "Production-quality WSGI server with very acceptable performance"
+conda = "waitress"
+pypi = "waitress"
+
+[[package]]
+description = "Measures number of Terminal column cells of wide-character codes."
+conda = "wcwidth"
+pypi = "wcwidth"
+
+[[package]]
+description = "WSGI request and response object"
+conda = "webob"
+pypi = "WebOb"
+
+[[package]]
+description = "helper to test WSGI applications"
+conda = "webtest"
+pypi = "WebTest"
+
+[[package]]
+description = "The Python WSGI Utility Library."
+conda = "werkzeug"
+pypi = "Werkzeug"
+
+[[package]]
+description = "A built-package format for Python."
+conda = "wheel"
+pypi = "wheel"
+
+[[package]]
+description = "File-based time-series database format for Graphite"
+conda = "whisper"
+pypi = "whisper"
+
+[[package]]
+description = "IPython HTML widgets for Jupyter"
+conda = "widgetsnbextension"
+pypi = "widgetsnbextension"
+
+[[package]]
+description = "Module for decorators, wrappers and monkey patching."
+conda = "wrapt"
+pypi = "wrapt"
+
+[[package]]
+description = "WebSocket client and server library for Python 2, 3, and PyPy"
+conda = "ws4py"
+pypi = "ws4py"
+
+[[package]]
+description = "A WSGI Proxy with various http client backends"
+conda = "wsgiproxy2"
+pypi = "WSGIProxy2"
+
+[[package]]
+description = "WSGI (PEP 333) Reference Library"
+conda = "wsgiref"
+pypi = "wsgiref"
+
+[[package]]
+description = "A flexible forms validation and rendering library for Python"
+conda = "wtforms"
+pypi = "WTForms"
+
+[[package]]
+description = "Cross platform GUI toolkit for Python, \"Phoenix\" version"
+conda = "wxpython"
+pypi = "wxPython"
+
+[[package]]
+description = "N-D labeled arrays and datasets in Python."
+conda = "xarray"
+pypi = "xarray"
+
+[[package]]
+description = "Library for developers to extract data from Microsoft Excel (tm) spreadsheet files"
+conda = "xlrd"
+pypi = "xlrd"
+
+[[package]]
+description = "A Python module for creating Excel XLSX files"
+conda = "xlsxwriter"
+pypi = "XlsxWriter"
+
+[[package]]
+description = "Writing data and formatting information to Excel files"
+conda = "xlwt"
+pypi = "xlwt"
+
+[[package]]
+description = "Revamped xmlrpc library for Python"
+conda = "xmlrpc2"
+pypi = "xmlrpc2"
+
+[[package]]
+description = "Yet another URL library"
+conda = "yarl"
+pypi = "yarl"
+
+[[package]]
+description = "Composable Dictionary Classes"
+conda = "zict"
+pypi = "zict"
+
+[[package]]
+description = "Backport of zipfile from Python 3.6"
+conda = "zipfile36"
+pypi = "zipfile36"
+
+[[package]]
+description = "Zope Component Architecture"
+conda = "zope.component"
+pypi = "zope.component"
+
+[[package]]
+description = "Zope Deprecation Infrastructure"
+conda = "zope.deprecation"
+pypi = "zope.deprecation"
+
+[[package]]
+description = "Very basic event publishing system"
+conda = "zope.event"
+pypi = "zope.event"
+
+[[package]]
+description = "Interfaces for Python"
+conda = "zope.interface"
+pypi = "zope.interface"
+
+[[package]]
+description = "Minimal Zope/SQLAlchemy transaction integration"
+conda = "zope.sqlalchemy"
+pypi = "zope.sqlalchemy"
+


### PR DESCRIPTION
I don't know if this is the right place to maintain the raw toml db.

I generated it like this:

```python
import argparse
import toml
from conda_build import api

if __name__ == '__main__':
  p = argparse.ArgumentParser(description="name-map-gen helper")

  p.add_argument(
          '--feedstock',
          action="store",
          required=True,
          help="path to feedstock")

  args = p.parse_args()

  ms = api.render(args.feedstock, finalize=False)

  final_set = set()
  for m, _, _ in ms:
    url = m.meta.get('source', {}).get('url')
    if 'pypi' not in url:
      continue
    pypi = url.split('/')[-2]
    summary = m.meta.get('about', {}).get('summary')
    name = m.meta.get('package', {}).get('name')
    final_set.add((name, pypi, summary))

  obj = {}
  obj['package'] = []
  for elem in final_set:
    pkgobj = {}
    pkgobj['description'] = elem[2]
    pkgobj['conda'] = elem[0]
    pkgobj['pypi'] = elem[1]
    obj['package'].append(pkgobj)

  if len(obj['package']) > 0:
    print(toml.dumps(obj))
```
```bash
[user@machine aggregate]$ find ./ -name meta.yaml | \
    xargs grep -l pypi | sort | \
    xargs -I{} python gen.py --feedstock {} | \
    grep -v 'Adding in variants' | grep -v 'Solving' 
```